### PR TITLE
feat(skills): specflow-audit Claude Code skill — journey = DoD (#46)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -40,3 +40,24 @@ appears in the skills list, then test with: `make this story specflow compliant`
 > Future direction: package the full Specflow toolset (agents, hooks, contracts,
 > skills) as a single Claude Code **plugin** so one install wires everything
 > together. This `skills/` directory is the first step toward that.
+
+## specflow-simulate
+
+Runs a story through multiple personas and divergent routes to surface gaps and
+edge cases **before** it's built, then proposes each finding as a concrete story
+addition (new REQ, negative-path AC, Gherkin branch, journey step). The
+high-value exploratory step right after create — distinct from the pre-flight
+gate.
+
+**Triggers on:** "simulate this story", "simulate usage end to end", "find gaps
+and edges", "run personas through this", "stress-test this story", or
+`/specflow-simulate <file-or-issue>`.
+
+Position in the flow:
+
+```
+create (specflow-writer) → simulate (specflow-simulate) → audit/uplift (specflow-audit) → pre-flight gate
+```
+
+Install the same way as specflow-audit (copy to `~/.claude/skills/` or
+`.claude/skills/`).

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,42 @@
+# Specflow Skills
+
+Claude Code skills that package Specflow workflows so they trigger on natural
+phrasing instead of requiring you to manually invoke an agent prompt.
+
+## specflow-audit
+
+Audits a Specflow story/ticket and surgically uplifts it to compliance, then
+runs a pre-flight gate that refuses to mark it compliant while CRITICAL/P1
+findings remain. Replaces ad-hoc inline "make it compliant" edits, which skip
+the gap-analysis, the section templates, and the pre-flight gate.
+
+**Triggers on:** "make specflow compliant", "specflow audit", "uplift this
+story", "run specflow auditor", "is this story compliant", or
+`/specflow-audit <file-or-issue>`.
+
+It wraps the `agents/board-auditor.md` → `agents/specflow-uplifter.md` →
+`agents/pre-flight-simulator.md` flow. The skill bundles condensed copies of the
+process under `references/`, so it works standalone in any repo; when the full
+Specflow repo is checked out it grounds against the canonical `agents/*.md` +
+`CONTRACT-SCHEMA.md` / `SPEC-FORMAT.md` / `USER-JOURNEY-CONTRACTS.md`.
+
+### Install
+
+User scope (available across all your projects):
+
+```bash
+cp -r skills/specflow-audit ~/.claude/skills/specflow-audit
+```
+
+Project scope (travels with one repo, shared with the team):
+
+```bash
+mkdir -p .claude/skills && cp -r skills/specflow-audit .claude/skills/specflow-audit
+```
+
+Restart Claude Code (or start a new session) to pick up the skill. Verify it
+appears in the skills list, then test with: `make this story specflow compliant`.
+
+> Future direction: package the full Specflow toolset (agents, hooks, contracts,
+> skills) as a single Claude Code **plugin** so one install wires everything
+> together. This `skills/` directory is the first step toward that.

--- a/skills/specflow-audit/SKILL.md
+++ b/skills/specflow-audit/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: specflow-audit
+description: Audits a Specflow story/ticket for spec-compliance and surgically uplifts it — adding only the missing executable contract sections (SQL/RLS, TypeScript interfaces, invariant codes, Gherkin, acceptance criteria, Definition of Done, data-testid coverage) — then runs a pre-flight gate that refuses to mark the ticket compliant while CRITICAL or P1 findings remain. This skill should be used when the user asks to "make specflow compliant", "specflow audit", "uplift this story", "run specflow auditor", "is this story compliant", or invokes /specflow-audit on a story file or GitHub issue. It is the reliable replacement for ad-hoc inline "make it compliant" edits, which skip the gap-analysis, the section templates, and the pre-flight gate. Scope is strictly Specflow story/contract work — do NOT trigger on generic "make this code/PR compliant" requests unrelated to Specflow specs.
+---
+
+# Specflow Audit & Uplift
+
+Take a partially-compliant Specflow story (some sections present, others missing) and bring it to compliance through a fixed three-phase process. The quality comes from the *process*, not improvisation — never freelance the uplift inline.
+
+## When to run
+
+Trigger on: "make specflow compliant", "specflow audit", "uplift this story / ticket", "run specflow auditor", "is this story compliant", or `/specflow-audit <file-or-issue>`.
+
+Do NOT trigger on generic "make this PR/code compliant" that has nothing to do with Specflow specs.
+
+The target is a **story/ticket** — a GitHub issue body, a `docs/specs/*.md` file, or pasted spec text. Not source code.
+
+## The non-negotiable process
+
+Run these three phases in order. Do not skip phase 3.
+
+### Phase 1 — Gap analysis (board-auditor)
+Read the target and diff it against the full Specflow template. Produce an explicit list of which sections are PRESENT and which are MISSING. The template sections are in `references/uplift-process.md`. Identify the ticket type (feature / bug / journey) — bug tickets legitimately N/A some sections; record the justification.
+
+### Phase 2 — Surgical uplift (specflow-uplifter)
+Add **only the missing sections** — never rewrite or duplicate existing content. Generate *executable* artifacts, not prose:
+- Data Contract: copy-pasteable `CREATE TABLE` / `CREATE FUNCTION` / RLS `CREATE POLICY` (use the join-through RLS pattern for tables without a direct org/owner column).
+- Frontend Interface: typed TypeScript hook/interface signatures matching project conventions.
+- Invariants Referenced: `I-<DOMAIN>-NNN` codes; reuse existing codes, take the next free number for new ones — never invent a code that already exists.
+- Gherkin Scenarios, Acceptance Criteria (behaviour-only checkboxes, including negative paths), Definition of Done, and `data-testid` coverage.
+
+Section templates and the RLS/invariant patterns are in `references/uplift-process.md`. Post the additions as one clearly-labelled uplift comment (GitHub) or appended block (file) — supplementing, not replacing.
+
+### Phase 3 — Pre-flight gate (HARD STOP)
+After uplift, simulate the combined ticket and assign findings a severity: CRITICAL / P1 / P2. The severity model and the `## Pre-flight Findings` section format are in `references/preflight-gate.md`.
+
+**The gate:** a ticket is compliant ONLY when pre-flight returns no CRITICAL and no P1.
+- CRITICAL or P1 remain → surface them, do NOT write a passing status, leave the ticket non-compliant.
+- Clean or P2-only → write the `## Pre-flight Findings` section with the appropriate `simulation_status` and mark compliant.
+
+Uplift does not grandfather prior failures. The auditor (this skill) never *declares* compliance on its own — pre-flight findings decide it.
+
+## Journey = Definition of Done (for any UI story)
+
+For a UI story, the **executable Playwright journey IS the Definition of Done** — not a side artifact. A story is not done because the code exists; it is done when a journey walks the user's steps and asserts the intended outcome was reached.
+
+A compliant UI journey must have:
+1. **Ordered, explicit steps** — the literal click/type/navigate sequence a real user takes, each step named.
+2. **Success criteria** — what observable state proves each step (and the journey overall) succeeded, asserted via `data-testid` / visible text / URL.
+3. **A runnable Playwright spec** mapped to the story's `J-<NAME>` id, encoding those steps and assertions.
+4. **Evidence it actually ran** — a pass result, OR an explicit "varied because of decision X" note explaining where the real flow legitimately diverged from the written steps and why that still satisfies intent. "Written but never executed" does not count as done.
+
+The audit therefore treats, for a UI story, as **CRITICAL** (blocks compliance):
+- no journey steps + success criteria in the story, or
+- no Playwright spec mapped to the `J-id`, or
+- a journey that has never been executed (no pass / no varied-with-reason record), or a deferral with no tracking issue.
+
+This is the single most common real-world failure ("journeys missing or not executed"); the gate exists to stop it.
+
+## How to execute
+
+1. Read the target (issue via `gh issue view <n> --json title,body,comments`, or the file).
+2. Ground against the canonical Specflow docs when present in the repo — full versions live at `<specflow-repo>/agents/{board-auditor,specflow-uplifter,pre-flight-simulator,specflow-writer}.md` and `CONTRACT-SCHEMA.md`, `SPEC-FORMAT.md`, `USER-JOURNEY-CONTRACTS.md`. Find the repo: it is the dir containing `CONTRACT-SCHEMA.md` (commonly `tooling/Specflow/` or a `Specflow/` subdir). If absent, the condensed `references/` files here are sufficient.
+3. Run Phase 1 → 2 → 3. For large stories, delegate Phase 1+2 to a subagent prompted with `references/uplift-process.md`, but always perform Phase 3 yourself.
+4. Cross-link material verdicts to the durable record (a `gh issue comment`), not just chat.
+
+## Reference files
+- `references/uplift-process.md` — template sections, the surgical-additions templates (SQL/RLS/TS/invariants/Gherkin/AC/DoD/testid), and the RLS join-through + invariant-domain patterns.
+- `references/preflight-gate.md` — CRITICAL/P1/P2 severity model, the compliance gate rule, and the `## Pre-flight Findings` section format.

--- a/skills/specflow-audit/references/preflight-gate.md
+++ b/skills/specflow-audit/references/preflight-gate.md
@@ -1,0 +1,84 @@
+# Pre-flight Gate
+
+Condensed from Specflow's `pre-flight-simulator.md`. Pre-flight is a **read-only**
+simulation of the uplifted ticket. It does not write code and does not write to
+GitHub — it returns findings. The auditor skill writes the result to the ticket
+ONLY when the gate passes.
+
+## What pre-flight simulates
+
+Walk the combined ticket (original body + uplift additions) and check, without
+writing code, whether a builder could implement it deterministically:
+
+- **Schema executes**: the SQL parses, references real tables/columns, no
+  duplicate migration timestamps, no RLS recursion (policy A ↔ policy B), no
+  dropped sibling behaviour when a function is `CREATE OR REPLACE`d.
+- **Contracts trace**: every `REQ-NN` maps to a contract/test; every invariant
+  code is unique and stated; named files have plausible paths.
+- **Journeys grounded**: each Gherkin scenario has the data-testids it needs;
+  personas cover happy + the key negative path.
+- **Journey = DoD (UI stories)**: the journey IS the definition of done. Check
+  all four, each a CRITICAL when absent:
+  1. ordered, explicit user **steps** are written;
+  2. each step has a **success criterion** (a testid / visible text / URL assertion);
+  3. a **Playwright spec exists** mapped to the story's `J-<NAME>` id and encodes
+     those steps + assertions (not a stub, not `test.skip`);
+  4. the journey has **actually executed** — a recorded pass, OR an explicit
+     "varied because of decision X" note (where the real flow legitimately
+     diverged and why intent is still met). "Written but never run" = CRITICAL.
+     A deferral is acceptable ONLY with a linked tracking issue; a bare skip is not.
+- **No naked claims**: acceptance criteria are observable behaviour, not
+  implementation detail; negative paths are present.
+- **Value-set parity**: enums/allowed-values in the spec match across SQL,
+  TypeScript, and validators (a classic drift source).
+
+## Severity model
+
+| Severity | Meaning | Effect on compliance |
+|----------|---------|----------------------|
+| **CRITICAL** | The ticket cannot be built/verified as written — broken SQL, missing required section for the ticket type, RLS recursion, migration collision, an invariant the work would violate, a `CREATE OR REPLACE` that drops existing behaviour, **or (UI story) the journey-as-DoD failures below**. | **Blocks compliance.** |
+| **P1** | A builder would very likely produce the wrong thing — value-set drift, a REQ with no test mapping, a journey with steps but a missing testid, an unstated cross-surface dependency (e.g. PDF payload not extended for a new field). | **Blocks compliance.** |
+| **P2** | Non-blocking polish — naming nits, a nice-to-have edge case, a reactive-state subtlety. | Does not block; log it. |
+
+## The gate (HARD STOP)
+
+A ticket is **compliant** only when pre-flight returns **no CRITICAL and no P1**.
+
+- **CRITICAL or P1 present** → surface every finding with its fix. Do NOT write a
+  passing `## Pre-flight Findings` section. Leave the ticket non-compliant and
+  report exactly what remains. The auditor never overrides this.
+- **Clean or P2-only** → write the `## Pre-flight Findings` section (below) with
+  the right `simulation_status` and mark compliant. Log P2s.
+
+Uplift does not grandfather previous failures: if uplift fixed some gaps but a
+CRITICAL/P1 remains, the ticket stays non-compliant.
+
+## `## Pre-flight Findings` section format
+
+Append this to the ticket body (via `gh issue edit <n>`) ONLY when the gate passes:
+
+```markdown
+## Pre-flight Findings
+
+**simulation_status:** passed | passed_with_warnings | blocked | stale | override:<reason>
+**simulated_at:** <RFC 3339 UTC, e.g. 2026-06-03T14:32:00Z>
+**scope:** ticket
+
+### CRITICAL
+None
+
+### P1
+None
+
+### P2
+- <non-blocking finding, or "None">
+```
+
+`simulation_status` values:
+- `passed` — no findings at any level.
+- `passed_with_warnings` — P2 only.
+- `blocked` — CRITICAL or P1 present (do NOT write this as a "compliant" result; report instead).
+- `stale` — the ticket changed after the last simulation; re-run.
+- `override:<reason>` — a human explicitly accepted a known finding; record who and why.
+
+Timestamps: do not invent a clock. Read the real UTC time (e.g. `date -u +%Y-%m-%dT%H:%M:%SZ`) when stamping `simulated_at`.

--- a/skills/specflow-audit/references/uplift-process.md
+++ b/skills/specflow-audit/references/uplift-process.md
@@ -1,0 +1,164 @@
+# Uplift Process — gap analysis + surgical additions
+
+Condensed from Specflow's `board-auditor.md` + `specflow-uplifter.md`. When the
+full Specflow repo is present (dir containing `CONTRACT-SCHEMA.md`), prefer its
+`agents/*.md` and `SPEC-FORMAT.md` / `CONTRACT-SCHEMA.md` / `USER-JOURNEY-CONTRACTS.md`.
+
+## Full template — the sections a compliant story carries
+
+A story/ticket is checked against these. Mark each PRESENT or MISSING.
+
+1. **Parent FEAT / Story ID** — links to epic; stable ID (e.g. `BILL-RATE-002`).
+2. **Personas / two-view framing** — who benefits; "Bob's view" + "Alice's view" or a Persona Simulation block (required for UI / workflow / permissions / agent / multi-actor features).
+3. **Scope** — In Scope / Not In Scope (Out-of-Scope items listed as separate tickets).
+4. **Requirements** — `REQ-NN (MUST|SHOULD)` lines, each atomic and testable.
+5. **Data Contract** — executable `CREATE TABLE` / `CREATE FUNCTION` / RLS `CREATE POLICY` / triggers / views / RPCs. (N/A only for tickets with no schema/DB surface — state why.)
+6. **Frontend Interface** — typed TypeScript hook/interface signatures.
+7. **Invariants Referenced** — `I-<DOMAIN>-NNN` codes with one-line statements.
+8. **Acceptance Criteria** — behaviour-only checkboxes, incl. negative paths.
+9. **Gherkin Scenarios** — Feature / Scenario / Given-When-Then; ≥1 happy + key edge/error.
+10. **Definition of Done** — checklist (tests, testids, manual repro).
+11. **data-testid Coverage** — every interactive element the journey tests touch.
+12. **SpecFlow Contract Mapping** — Contracts / Contract Tests / Journey Tests subsections with file paths.
+13. **Relevant ADRs** — architecture decisions the work must honour.
+
+### Ticket-type pragmatism
+- **Bug ticket**: Data Contract may be N/A (no schema change) — but still document the existing shape + the constraint/trigger being violated. Frontend Interface, Gherkin (happy + the bug's negative path), DoD, testids still required.
+- **Journey ticket**: Persona Simulation + Gherkin + journey-test mapping are the core; lighter on schema.
+- **Feature ticket**: all sections.
+
+## Surgical additions — generate ONLY what's missing
+
+Never duplicate or rewrite existing content. Each missing section gets executable, copy-pasteable artifacts.
+
+### Missing Data Contract → executable SQL
+```sql
+CREATE TABLE zone (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  space_id UUID NOT NULL REFERENCES space(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  UNIQUE(space_id, name)
+);
+```
+For functions, prefer `CREATE OR REPLACE FUNCTION ... SECURITY DEFINER SET search_path = public`. When replacing an existing function, **read its current body first** and preserve unrelated behaviour (notify inserts, audit rows, idempotency) — a rewrite that drops a sibling invariant is a regression.
+
+### Missing RLS → join-through pattern (tables without a direct org/owner column)
+```sql
+-- direct owner column (simple)
+USING (organization_id IN (SELECT organization_id FROM employees WHERE user_id = auth.uid()))
+
+-- one-level join (space → site.org_id)
+USING ((SELECT org_id FROM site WHERE id = space.site_id)
+       IN (SELECT organization_id FROM employees WHERE user_id = auth.uid()))
+
+-- two-level join (zone → space → site.org_id)
+USING ((SELECT s.org_id FROM site s JOIN space sp ON sp.site_id = s.id
+        WHERE sp.id = zone.space_id)
+       IN (SELECT organization_id FROM employees WHERE user_id = auth.uid()))
+```
+RLS recursion warning: never write policy on A that subqueries B while B's policy subqueries A — Postgres returns HTTP 500 for all queries. Use `SECURITY DEFINER` helper functions that bypass RLS, and call those in policies.
+
+### Missing Frontend Interface → typed signatures
+```typescript
+export interface UseZonesReturn {
+  zones: Zone[];
+  isLoading: boolean;
+  error: Error | null;
+  createZone: (input: CreateZoneInput) => Promise<Zone>;
+  reorderZones: (orderedIds: string[]) => Promise<void>;
+}
+```
+
+### Missing Invariants → registry codes
+```markdown
+## Invariants Referenced
+- I-ADM-003: Every space must have at least one zone (auto-create trigger).
+- I-ADM-004: Zone names unique within a space (UNIQUE constraint).
+```
+Reuse existing `I-<DOMAIN>-NNN` codes; for a genuinely new rule, take the next free number in that domain — grep the codebase/contracts first; never reuse or collide an existing code. Domain prefixes (extend as needed): `I-OPS` ops/rooms, `I-NTF` notifications, `I-SCH` scheduling, `I-PTO` leave, `I-PAY` payroll, `I-ENT` entitlements, `I-ADM` admin/config, `I-AUTH` auth, `I-BILL` billing, `I-TIME` time/timesheets.
+
+### Missing Gherkin
+```gherkin
+Feature: <feature name>
+  Scenario: <happy path>
+    Given <precondition>
+    When <action>
+    Then <observable outcome>
+  Scenario: <the negative/error path the ticket must handle>
+    Given ...
+    When ...
+    Then <explicit error / no-op>
+```
+
+### Missing Acceptance Criteria — behaviour-only checkboxes
+```markdown
+- [ ] AC-1: <observable behaviour, not implementation detail>
+- [ ] AC-2: <negative path — what must NOT happen / explicit error>
+```
+
+### Missing Definition of Done
+```markdown
+- [ ] Unit/contract tests added and passing
+- [ ] data-testids present on all interactive elements
+- [ ] Negative paths covered
+- [ ] Manual repro on <surface/URL> clean
+```
+
+### Missing data-testid Coverage
+```markdown
+- `zone-list-{spaceId}` — list container
+- `create-zone-btn` — create button
+- `zone-name-input` — name field
+```
+
+### Missing SpecFlow Contract Mapping
+```markdown
+## SpecFlow Contract Mapping
+### Contracts
+- docs/contracts/feature_<name>.yml — REQ-NN..NN; invariant_<code>.yml
+### Contract Tests
+- src/__tests__/contracts/<name>_contract.test.ts — pins <what>
+### Journey Tests
+- tests/e2e/<journey>.spec.ts — J-<NAME>, Persona <name> end-to-end
+```
+
+### Missing / weak Journey (UI stories) — journey IS the Definition of Done
+A UI story is done when a Playwright journey walks the user's steps and asserts
+intent was reached. Uplift must add an **executable journey spec**, not prose.
+Structure every journey as ordered steps, each with a success assertion:
+
+```markdown
+## Journey: J-<NAME> — <one-line outcome the user wants>
+Persona: <who> · Surface: <url/route>
+
+| # | Step (user action) | Success criterion (assertion) |
+|---|--------------------|-------------------------------|
+| 1 | Navigate to /billing | `billing-engagements-list` visible |
+| 2 | Click engagement row | URL = /billing/{id}; `billing-period-view` visible |
+| 3 | Select week, click Submit invoice | `invoice-line-units` shows "4 days × …" |
+| 4 | Owner approves, then Mark Paid + ref | status badge = "paid"; `mark-paid-ref` persisted |
+
+Done = this journey passes, OR a "varied because of <decision>" note explains a
+legitimate divergence and why intent is still met.
+```
+
+```typescript
+// tests/e2e/<journey>.spec.ts  (J-<NAME>)
+import { test, expect } from '@playwright/test'
+test('J-<NAME>: <outcome>', async ({ page }) => {
+  await page.goto('/billing')
+  await expect(page.getByTestId('billing-engagements-list')).toBeVisible()
+  // ...one block per step, each ending in an assertion that proves the step...
+})
+```
+
+Rules for the uplift:
+- Every interactive step references a real `data-testid` (add any missing ones to the testid section).
+- No `test.skip` / stub bodies — a skipped journey is not done.
+- The DoD checklist must include: "Journey J-<NAME> executed and passing (or varied-with-reason recorded)."
+- If the journey genuinely can't run yet, add a deferral line with a linked tracking issue — never a silent skip.
+
+## Posting the uplift
+- GitHub issue: one `gh issue comment <n> --body-file <tmp>` titled e.g. `## Specflow Uplift: <missing sections>`. Supplement; do not replace the body.
+- File: append a clearly-marked block; do not rewrite existing sections.
+- Batch (multiple issues in an epic): keep RLS join pattern, invariant registry, and naming consistent across them; run pre-flight per-ticket — never batch-mark compliant.

--- a/skills/specflow-simulate/SKILL.md
+++ b/skills/specflow-simulate/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: specflow-simulate
+description: Simulates end-to-end usage of a Specflow story across multiple personas and divergent routes to discover gaps, edge cases, and unhandled branches BEFORE the story is built — then proposes each finding as a concrete story addition (new REQ, negative-path AC, Gherkin branch, or journey step). This is the high-value exploratory step run right after a story is created, distinct from the pre-flight compliance gate. This skill should be used when the user asks to "simulate this story", "simulate usage end to end", "find gaps and edges", "run personas through this", "stress-test this story", or invokes /specflow-simulate on a story file or GitHub issue. Scope is Specflow story exploration — it is generative (surfaces and proposes), not a build or a verification gate.
+---
+
+# Specflow Simulate
+
+Run a story through realistic usage — multiple personas, multiple routes — to find the gaps and edges a single happy-path reading misses. The output is not commentary; it is a set of concrete, proposed additions that make the story sharper before any code is written.
+
+## When to run
+
+Trigger on: "simulate this story", "simulate usage end to end", "find gaps / edges", "run personas through this", "stress-test this story", or `/specflow-simulate <file-or-issue>`.
+
+Position in the Specflow flow — this runs *after create, before audit*:
+```
+create (specflow-writer) → SIMULATE (this skill) → audit/uplift (specflow-audit) → pre-flight gate
+```
+It is generative (discover + propose). It is NOT the pre-flight gate (that verifies and blocks). Do not conflate the two.
+
+## The method
+
+Full method (persona archetypes, route taxonomy, gap→edit mapping, output format) is in `references/simulation-method.md`. Summary:
+
+1. **Read the story** (issue via `gh issue view <n> --json title,body,comments`, or the file). Extract the intended outcome, the actors, and the surfaces.
+2. **Derive 3–5 distinct personas** — not demographics; *behavioural archetypes* that route through the problem differently (e.g. power user, first-timer, adversarial/edge user, wrong-permissions user, interrupted/returning user). Pick the ones that stress *this* story.
+3. **Walk each persona through the story end-to-end** — the happy path AND at least one divergent route per persona: where do they get confused, blocked, take an unanticipated branch, hit an empty/error/permission state, or make a decision the story didn't plan for?
+4. **Collect gaps** — each gap is a concrete moment where the story is silent, ambiguous, or wrong for that persona/route.
+5. **Map every gap to a story edit** — a new `REQ-NN`, a negative-path `AC`, a new Gherkin scenario/branch, a new journey step + `data-testid`, or a flagged open question. A gap with no proposed edit is incomplete.
+6. **Propose, don't silently rewrite** — post the findings as ONE labelled block: a GitHub comment (`gh issue comment`) or an appended `## Simulation Findings (proposed)` section. The user (or the subsequent specflow-audit uplift) folds accepted items into the story body. Only edit the body directly if the user explicitly says to apply.
+
+## Parallel personas (optional, for thorough runs)
+For a deep simulation, fan out one agent per persona so each route is explored independently and blind to the others — this surfaces more than one sequential reading. The `ux-critique` skill already runs parallel persona agents against a live screen; reuse that pattern here, scoped to the *story text* rather than a running UI. Then dedupe and synthesize into the single findings block.
+
+## Output shape
+Report, and post as the findings block:
+- the personas chosen and why each stresses this story,
+- per persona: the route taken + the gaps found,
+- a consolidated **proposed-additions** list (REQ / AC / Gherkin / journey-step), each tagged with the persona/route that motivated it,
+- open questions that need a human decision (don't invent answers to product questions).
+
+## Reference
+- `references/simulation-method.md` — persona archetypes, route taxonomy, gap→edit mapping table, and the `## Simulation Findings (proposed)` format.

--- a/skills/specflow-simulate/references/simulation-method.md
+++ b/skills/specflow-simulate/references/simulation-method.md
@@ -1,0 +1,83 @@
+# Simulation Method — personas × routes → proposed story edits
+
+The goal: surface what a single happy-path reading of the story misses, by
+running realistic actors through it on realistic (and adversarial) routes, then
+turning every gap into a concrete proposed addition. Pairs with the
+`specflow-audit` skill (run simulate first; audit/pre-flight after).
+
+## Step 1 — derive personas (3–5)
+
+Personas are **behavioural archetypes**, not demographics. Pick the ones that
+actually stress *this* story. A useful starting set:
+
+| Archetype | What they stress |
+|-----------|------------------|
+| Power user / repeat | shortcuts, bulk actions, MRU/state, "I've done this 50 times" |
+| First-timer | empty states, onboarding, unlabeled affordances, defaults |
+| Adversarial / edge | bad input, huge/zero/negative values, unicode, double-submit, back button |
+| Wrong-permissions | non-owner, expired session, cross-tenant, read-only role |
+| Interrupted / returning | mid-flow reload, tab switch, stale data, resume after days |
+| Cross-surface | starts on one surface (e.g. CLI/extension), finishes on another (web) |
+| Collaborator / multi-actor | two people acting on the same object; ordering and races |
+
+For each chosen persona, state in one line *why it stresses this story* — if it
+doesn't, drop it.
+
+## Step 2 — route each persona end-to-end
+
+For every persona, walk the story's flow twice:
+- **Happy route** — the intended path; confirm the story actually supports it step by step.
+- **≥1 divergent route** — the realistic place this persona deviates: an empty/error/permission state, an unanticipated branch, a decision the story is silent on, a back-out/cancel, a concurrent action, a retry.
+
+At each step ask: *Does the story say what happens here? Is the success state observable? What does this persona expect that the story doesn't deliver?*
+
+## Step 3 — collect gaps, map each to a story edit
+
+A gap with no proposed edit is incomplete. Map every gap to one of:
+
+| Gap kind | Becomes |
+|----------|---------|
+| Silent behaviour / missing rule | a new `REQ-NN (MUST|SHOULD)` |
+| Unhandled error/empty/permission state | a negative-path `AC` + a Gherkin scenario |
+| Divergent route not covered | a new Gherkin branch and/or a journey step + `data-testid` |
+| Ambiguous wording | a clarifying REQ edit or an open question |
+| Cross-surface/ordering/race | an explicit REQ + an invariant `I-<DOMAIN>-NNN` candidate |
+| Product decision needed | an **open question** (do NOT invent the answer) |
+
+## Step 4 — output as a proposed block (do not silently rewrite)
+
+Post ONE labelled block — `gh issue comment` or an appended section. Default is
+*propose*; only apply into the story body if the user says so.
+
+```markdown
+## Simulation Findings (proposed)
+
+**Personas run:** <persona> (why), <persona> (why), …
+**simulated_at:** <RFC 3339 UTC>
+
+### Per-persona routes
+- **<persona> — <route>**: <what happened> → gap: <the silence/edge>
+- …
+
+### Proposed additions (accept into the story, then run specflow-audit)
+- [ ] REQ-NN (MUST): <rule the story was missing>  — from <persona/route>
+- [ ] AC: <observable negative-path behaviour>  — from <persona/route>
+- [ ] Gherkin: Scenario "<edge>" Given/When/Then …  — from <persona/route>
+- [ ] Journey step: <step> → assert `data-testid="…"`  — from <persona/route>
+
+### Open questions (need a human decision)
+- <product/UX question the simulation surfaced — no invented answer>
+```
+
+## Parallel fan-out (deep runs)
+For thorough simulation, spawn one agent per persona so routes are explored
+independently (each blind to the others), then dedupe and synthesize into the
+single block above. The `ux-critique` skill already runs parallel persona agents
+against a live screen — reuse that machinery, scoped to the story text. Always
+collapse to one consolidated findings block; never post N overlapping comments.
+
+## Discipline
+- Personas must route *differently* — five personas that all walk the happy path is one simulation, not five.
+- Every finding cites the persona+route that motivated it (traceability).
+- Don't answer product questions; surface them.
+- The output improves the artifact (proposed edits), it is not a critique essay.


### PR DESCRIPTION
Closes #46.

Packages the **board-auditor → specflow-uplifter → pre-flight-simulator** flow as a Claude Code **skill** that auto-triggers on the phrasing users already use — "make specflow compliant", "uplift this story", "is this story compliant", `/specflow-audit` — instead of requiring manual agent invocation. Inline "make it compliant" requests skip the gap-analysis, the section templates, and the pre-flight gate and produce poor uplifts; the skill loads the structured process *before* acting, so the trigger phrase becomes the process.

## Headline: journey = Definition of Done (UI stories)

Addresses the #1 real-world Specflow failure — *journeys missing or not executed*. For any UI story the executable Playwright journey **IS** the DoD:
1. ordered, explicit user **steps**
2. a **success criterion** per step (testid / visible text / URL assertion)
3. a **Playwright spec** mapped to the `J-<NAME>` id (not a stub, not `test.skip`)
4. **evidence it ran** — a pass, or an explicit "varied because of decision X" note

Missing steps/success, a missing/stubbed spec, or a never-executed journey is **CRITICAL** in pre-flight and blocks compliance. A deferral is allowed only with a linked tracking issue.

## Contents
- `skills/specflow-audit/SKILL.md` — 3-phase process (gap analysis → surgical additions → hard pre-flight gate) + journey-as-DoD; tightly-scoped description so it won't over-fire on generic "make this compliant".
- `references/uplift-process.md` — full template sections + executable surgical-addition templates (SQL/RLS join-through, TS interfaces, `I-<DOMAIN>-NNN` invariants, Gherkin, AC, DoD, data-testid, **journey step/success table + Playwright spec**).
- `references/preflight-gate.md` — CRITICAL/P1/P2 severity model with the journey-as-DoD CRITICAL rules + `## Pre-flight Findings` format.
- `skills/README.md` — install (user/project scope) + plugin direction.

Bundled references make the skill standalone in any repo; when the full Specflow repo is checked out it grounds against the canonical `agents/*.md` and `CONTRACT-SCHEMA`/`SPEC-FORMAT`/`USER-JOURNEY-CONTRACTS`.

Already installed at user scope (`~/.claude/skills/specflow-audit/`) for the author; this PR is the distribution copy for future Specflow users.

> Validated with `skill-creator`'s `quick_validate.py` (passes). Note: future direction is to roll agents + hooks + contracts + skills into one Claude Code **plugin** so a single install wires everything together.