### PR TITLE
feat(gate-b): ticket↔journey enumerator — the →issue join (#52)

### DIFF
--- a/scripts/verify-ticket-journey.cjs
+++ b/scripts/verify-ticket-journey.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * verify-ticket-journey.cjs — Gate B, leg 3 (the "→issue" join).
+ *
+ * `verify-graph.cjs` validates the CONTRACT graph (requirement→journey→test→contract)
+ * but has no issue-awareness. This script closes the ticket↔journey join, model-free:
+ *   - every journey defined in the contracts dir is referenced by ≥1 GitHub ticket (no orphan journeys)
+ *   - every journey ID a ticket references actually exists (no dangling ticket refs)
+ *
+ * It does NOT re-implement the contract graph — it consumes journey IDs and issues only.
+ *
+ * Usage:
+ *   node scripts/verify-ticket-journey.cjs [contracts-dir] [--repo OWNER/REPO]
+ *   node scripts/verify-ticket-journey.cjs [contracts-dir] --issues path/to/issues.json   # offline/testing
+ *
+ * Exit 0 = pass, 1 = orphans or dangling refs found, 2 = usage/IO error.
+ */
+
+const { readdirSync, readFileSync, existsSync, statSync } = require('fs');
+const { join } = require('path');
+const { execSync } = require('child_process');
+
+const JOURNEY_ID = /\bJ-[A-Z0-9]+(?:-[A-Z0-9]+)*\b/g;
+
+/** Journey IDs *defined* in a contract file: `id: J-...` under journey_meta. */
+function extractDefinedJourneyIds(content) {
+  const out = new Set();
+  const matches = content.match(/id:\s*(J-[A-Z0-9-]+)/g) || [];
+  for (const m of matches) out.add(m.replace('id:', '').trim());
+  return out;
+}
+
+/** Load the set of journey IDs defined across a contracts directory. */
+function loadJourneyIds(contractsDir) {
+  const ids = new Set();
+  if (!existsSync(contractsDir)) return ids;
+  for (const f of readdirSync(contractsDir)) {
+    if (!/\.ya?ml$/.test(f)) continue;
+    const p = join(contractsDir, f);
+    if (!statSync(p).isFile()) continue;
+    for (const id of extractDefinedJourneyIds(readFileSync(p, 'utf8'))) ids.add(id);
+  }
+  return ids;
+}
+
+/** Map each issue to the journey IDs it references in its body/title. */
+function parseTicketRefs(issues) {
+  const refs = new Map(); // issueNumber → Set(J-id)
+  for (const issue of issues) {
+    const text = `${issue.title || ''}\n${issue.body || ''}`;
+    const found = new Set(text.match(JOURNEY_ID) || []);
+    refs.set(issue.number, found);
+  }
+  return refs;
+}
+
+/**
+ * The join. Pure — no IO.
+ * @param {Set<string>} journeyIds  journey IDs defined in contracts
+ * @param {Array} issues            [{number, title, body}]
+ * @returns {{orphanJourneys:string[], danglingTickets:Array<{number:number,badIds:string[]}>, pass:boolean}}
+ */
+function auditTicketJourney(journeyIds, issues) {
+  const refs = parseTicketRefs(issues);
+  const referenced = new Set();
+  const danglingTickets = [];
+
+  for (const [number, ids] of refs) {
+    const badIds = [];
+    for (const id of ids) {
+      if (journeyIds.has(id)) referenced.add(id);
+      else badIds.push(id);
+    }
+    if (badIds.length) danglingTickets.push({ number, badIds: badIds.sort() });
+  }
+
+  const orphanJourneys = [...journeyIds].filter(id => !referenced.has(id)).sort();
+  danglingTickets.sort((a, b) => a.number - b.number);
+  return { orphanJourneys, danglingTickets, pass: orphanJourneys.length === 0 && danglingTickets.length === 0 };
+}
+
+/** Fetch issues from GitHub via gh (open issues by default). */
+function fetchIssuesFromGh(repo) {
+  const repoFlag = repo ? `-R ${repo}` : '';
+  const raw = execSync(`gh issue list ${repoFlag} --state open --limit 1000 --json number,title,body`, {
+    encoding: 'utf8',
+  });
+  return JSON.parse(raw);
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const issuesFlagIdx = args.indexOf('--issues');
+  const repoFlagIdx = args.indexOf('--repo');
+  const consumed = new Set(); // indices that are flag *values*, not the positional contracts-dir
+  if (issuesFlagIdx !== -1) consumed.add(issuesFlagIdx + 1);
+  if (repoFlagIdx !== -1) consumed.add(repoFlagIdx + 1);
+  const contractsDir = args.find((a, i) => !a.startsWith('--') && !consumed.has(i)) || 'docs/contracts';
+
+  let issues;
+  try {
+    if (issuesFlagIdx !== -1) {
+      issues = JSON.parse(readFileSync(args[issuesFlagIdx + 1], 'utf8'));
+    } else {
+      issues = fetchIssuesFromGh(repoFlagIdx !== -1 ? args[repoFlagIdx + 1] : null);
+    }
+  } catch (e) {
+    console.error(`✗ could not load issues: ${e.message}`);
+    process.exit(2);
+  }
+
+  const journeyIds = loadJourneyIds(contractsDir);
+  console.error(`\nGate B leg 3 — ticket↔journey join (${journeyIds.size} journeys, ${issues.length} issues)`);
+  console.error('------------------------------------------------------------');
+
+  const { orphanJourneys, danglingTickets, pass } = auditTicketJourney(journeyIds, issues);
+
+  for (const id of orphanJourneys) console.error(`  \x1b[31m✗\x1b[0m orphan journey (no ticket): ${id}`);
+  for (const { number, badIds } of danglingTickets)
+    console.error(`  \x1b[31m✗\x1b[0m ticket #${number} references unknown journey(s): ${badIds.join(', ')}`);
+
+  if (pass) {
+    console.error(`  \x1b[32m✓\x1b[0m every journey has a ticket; every ticket ref resolves`);
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
+module.exports = { extractDefinedJourneyIds, loadJourneyIds, parseTicketRefs, auditTicketJourney };
+
+if (require.main === module) main(process.argv);

--- a/tests/contracts/ticket-journey.test.js
+++ b/tests/contracts/ticket-journey.test.js
@@ -1,0 +1,83 @@
+/**
+ * Gate B leg 3 — ticket↔journey join (verify-ticket-journey.cjs).
+ *
+ * Oracle: journey IDs are read from the REAL fixture contracts
+ * (sample apps/AISP-Specflow/docs/contracts), never hardcoded by guess.
+ */
+
+const { resolve } = require('path');
+const {
+  loadJourneyIds,
+  parseTicketRefs,
+  auditTicketJourney,
+} = require('../../scripts/verify-ticket-journey.cjs');
+
+const FIXTURE_CONTRACTS = resolve(__dirname, '../../sample apps/AISP-Specflow/docs/contracts');
+
+describe('loadJourneyIds (anchored to real fixtures)', () => {
+  test('extracts exactly the journey IDs defined in the fixture contracts', () => {
+    const ids = loadJourneyIds(FIXTURE_CONTRACTS);
+    // Oracle: the three journey_*.yml fixtures define these IDs.
+    expect([...ids].sort()).toEqual(['J-TODO-COMPLETE', 'J-TODO-CREATE', 'J-TODO-DELETE']);
+  });
+
+  test('returns empty set for a non-existent dir (no throw)', () => {
+    expect(loadJourneyIds(resolve(__dirname, 'does-not-exist')).size).toBe(0);
+  });
+});
+
+describe('parseTicketRefs', () => {
+  test('extracts J- references from title and body', () => {
+    const refs = parseTicketRefs([
+      { number: 1, title: 'Implement J-TODO-CREATE', body: 'see also J-TODO-COMPLETE' },
+      { number: 2, title: 'no refs here', body: 'plain text' },
+    ]);
+    expect([...refs.get(1)].sort()).toEqual(['J-TODO-COMPLETE', 'J-TODO-CREATE']);
+    expect(refs.get(2).size).toBe(0);
+  });
+
+  test('does not match J- substrings mid-word', () => {
+    const refs = parseTicketRefs([{ number: 3, title: '', body: 'NOTAJ-THING and majJ-X' }]);
+    expect(refs.get(3).size).toBe(0);
+  });
+});
+
+describe('auditTicketJourney (the join)', () => {
+  const journeyIds = loadJourneyIds(FIXTURE_CONTRACTS); // real oracle
+
+  test('passes when every journey has a ticket and every ref resolves', () => {
+    const issues = [
+      { number: 10, title: 'J-TODO-CREATE', body: '' },
+      { number: 11, title: 'J-TODO-COMPLETE', body: '' },
+      { number: 12, title: 'J-TODO-DELETE', body: '' },
+    ];
+    const r = auditTicketJourney(journeyIds, issues);
+    expect(r.orphanJourneys).toEqual([]);
+    expect(r.danglingTickets).toEqual([]);
+    expect(r.pass).toBe(true);
+  });
+
+  test('flags an orphan journey (defined, no ticket)', () => {
+    const issues = [
+      { number: 10, title: 'J-TODO-CREATE', body: '' },
+      { number: 11, title: 'J-TODO-COMPLETE', body: '' },
+      // J-TODO-DELETE intentionally uncovered
+    ];
+    const r = auditTicketJourney(journeyIds, issues);
+    expect(r.orphanJourneys).toEqual(['J-TODO-DELETE']);
+    expect(r.pass).toBe(false);
+  });
+
+  test('flags a dangling ticket ref (journey ID that does not exist)', () => {
+    const issues = [
+      { number: 10, title: 'J-TODO-CREATE', body: '' },
+      { number: 11, title: 'J-TODO-COMPLETE', body: '' },
+      { number: 12, title: 'J-TODO-DELETE', body: '' },
+      { number: 13, title: 'J-TODO-NOPE', body: 'references a journey that was never defined' },
+    ];
+    const r = auditTicketJourney(journeyIds, issues);
+    expect(r.orphanJourneys).toEqual([]);
+    expect(r.danglingTickets).toEqual([{ number: 13, badIds: ['J-TODO-NOPE'] }]);
+    expect(r.pass).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #52. Part of EPIC #48 (pipeline v2).

Gate B leg 3 — the ticket↔journey "→issue" join that `verify-graph.cjs` doesn't cover (no issue-awareness). The round-2 adversary on the PRD proved this leg was missing; this is the only new code (the contract graph is reused, not forked).

## What
- `scripts/verify-ticket-journey.cjs` — model-free: flags **orphan journeys** (defined, no ticket) and **dangling ticket refs** (ticket cites an unknown journey ID). Pure join + thin `gh` wrapper.
- `tests/contracts/ticket-journey.test.js` — assertions **oracle-anchored** to the real fixture journey IDs (`J-TODO-CREATE/COMPLETE/DELETE`), not guessed.

## Evidence
- `npx jest tests/contracts/ticket-journey.test.js` → **7/7 passed**.
- CLI verified vs real fixtures: orphan → reports `J-TODO-DELETE` (exit 1); full coverage → pass (exit 0).
- Regression: full suite 83→90 passed; **29 failures are inherited baseline** (proven by stashing these files on a pristine clone) — **0 new failures**.
- Caught + fixed an arg-parsing bug by running the CLI for real before commit.

## Not in scope
- The 29 inherited-baseline failures in Specflow 0.6.0 (separate tracking issue suggested).