### PR TITLE
feat(gate-a): mechanical seed byte-check + versioned adversary mandate (#50)

### DIFF
--- a/scripts/verify-seed.cjs
+++ b/scripts/verify-seed.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * verify-seed.cjs — the independence GATE for the adversary spawn (pipeline-v2 #50 / N2).
+ *
+ * "Fresh context" is honour-system unless the seed is auditable. So the spawn seed must match a
+ * FIXED template — exactly three slots, no free text — and is byte-checked here BEFORE the adversary
+ * is spawned. A primed seed (one carrying the author's rationale/chain-of-thought) fails this check
+ * and cannot launch. This, not the fresh window alone, is what makes the adversary independent.
+ *
+ *   seed = {
+ *     artifact_paths: ["PRDs/foo-prd.md", ...],   // non-empty array of strings
+ *     tool_grants:    ["read","grep","bash"],      // subset of the allow-list below
+ *     mandate_ref:    "adversary-mandate@v1"        // id of a versioned static mandate, NOT prose
+ *   }
+ *
+ * No other keys are permitted — `rationale`, `context`, `notes`, `why`, etc. are exactly the
+ * priming-leak vectors this gate exists to reject.
+ *
+ * Usage:  node scripts/verify-seed.cjs <seed.json>     (exit 0 = valid, 1 = rejected, 2 = IO error)
+ */
+
+const { readFileSync } = require('fs');
+
+const ALLOWED_KEYS = ['artifact_paths', 'tool_grants', 'mandate_ref'];
+const TOOL_ALLOWLIST = ['read', 'grep', 'glob', 'bash'];
+const MANDATE_REF = /^[a-z][a-z0-9-]*@v\d+$/; // e.g. adversary-mandate@v1 — an id, never free text
+
+/**
+ * Pure validator. No IO.
+ * @returns {{ok:boolean, violations:string[]}}
+ */
+function validateSeed(seed) {
+  const v = [];
+
+  if (seed === null || typeof seed !== 'object' || Array.isArray(seed)) {
+    return { ok: false, violations: ['seed must be a JSON object'] };
+  }
+
+  // Exactly the three allowed keys — extra keys are the priming-leak vector.
+  const keys = Object.keys(seed);
+  for (const k of keys) {
+    if (!ALLOWED_KEYS.includes(k)) v.push(`disallowed key: "${k}" (only ${ALLOWED_KEYS.join(', ')} permitted)`);
+  }
+  for (const k of ALLOWED_KEYS) {
+    if (!keys.includes(k)) v.push(`missing key: "${k}"`);
+  }
+
+  // artifact_paths — non-empty array of non-empty strings.
+  if ('artifact_paths' in seed) {
+    const ap = seed.artifact_paths;
+    if (!Array.isArray(ap) || ap.length === 0) v.push('artifact_paths must be a non-empty array');
+    else if (!ap.every(p => typeof p === 'string' && p.trim().length > 0)) v.push('artifact_paths must be non-empty strings');
+  }
+
+  // tool_grants — array drawn only from the allow-list.
+  if ('tool_grants' in seed) {
+    const tg = seed.tool_grants;
+    if (!Array.isArray(tg)) v.push('tool_grants must be an array');
+    else for (const t of tg) if (!TOOL_ALLOWLIST.includes(t)) v.push(`tool_grant not allowed: "${t}" (allow-list: ${TOOL_ALLOWLIST.join(', ')})`);
+  }
+
+  // mandate_ref — an id matching the versioned pattern, NOT inlined prose.
+  if ('mandate_ref' in seed) {
+    const m = seed.mandate_ref;
+    if (typeof m !== 'string' || !MANDATE_REF.test(m)) {
+      v.push('mandate_ref must be a versioned id like "adversary-mandate@v1" (an id, not prose)');
+    }
+  }
+
+  return { ok: v.length === 0, violations: v };
+}
+
+function main(argv) {
+  const path = argv[2];
+  if (!path) {
+    console.error('Usage: node scripts/verify-seed.cjs <seed.json>');
+    process.exit(2);
+  }
+  let seed;
+  try {
+    seed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    console.error(`✗ could not read/parse ${path}: ${e.message}`);
+    process.exit(2);
+  }
+  const { ok, violations } = validateSeed(seed);
+  if (ok) {
+    console.error('\x1b[32m✓\x1b[0m seed matches the template — adversary may launch');
+    process.exit(0);
+  }
+  console.error('\x1b[31m✗\x1b[0m seed rejected — a primed seed cannot launch:');
+  for (const msg of violations) console.error(`  - ${msg}`);
+  process.exit(1);
+}
+
+module.exports = { validateSeed, ALLOWED_KEYS, TOOL_ALLOWLIST, MANDATE_REF };
+
+if (require.main === module) main(process.argv);

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -151,7 +151,7 @@ echo -e "${BLUE}[4b/10]${NC} Copying loop kit + process docs..."
 if [ -d "$SCRIPT_DIR/templates/loops" ]; then
   mkdir -p "$TARGET_DIR/QA/loops/prompts" "$TARGET_DIR/QA/loops/examples"
   cp "$SCRIPT_DIR/templates/loops/"*.yaml "$TARGET_DIR/QA/loops/" 2>/dev/null || true
-  cp "$SCRIPT_DIR/templates/loops/README.md" "$TARGET_DIR/QA/loops/" 2>/dev/null || true
+  cp "$SCRIPT_DIR/templates/loops/"*.md "$TARGET_DIR/QA/loops/" 2>/dev/null || true   # README + adversary-mandate@v1
   cp "$SCRIPT_DIR/templates/loops/prompts/"*.md "$TARGET_DIR/QA/loops/prompts/" 2>/dev/null || true
   cp "$SCRIPT_DIR/templates/loops/examples/"*.md "$TARGET_DIR/QA/loops/examples/" 2>/dev/null || true
   echo -e "${GREEN}✓${NC} Copied QA/loops/ (paths + prompts + example)"

--- a/templates/loops/adversary-mandate.md
+++ b/templates/loops/adversary-mandate.md
@@ -1,0 +1,16 @@
+# adversary-mandate@v1
+
+Static, versioned instructions an independent adversary runs. **The spawn seed references this file by id (`adversary-mandate@v1`) — it never inlines the mandate or any author rationale.** That separation is what makes the seed mechanically auditable (see `scripts/verify-seed.cjs`): the seed carries only *which* mandate, never *prose*.
+
+## Mandate
+
+You are a hostile, independent critic. You did not write the artifact and have no stake in it. Default to skepticism.
+
+1. **Reality-grounding ledger** — open every concrete claim the artifact makes about the real system and VERIFY it against the actual files. Report VERIFIED (file:line + quote) or FALSE/UNSUPPORTED.
+2. **Loophole hunt** — actively try to find a gamed gate, fake backend, no-data path, skip-to-green, or always-green metric *surviving*.
+3. **7-pass rubric** — JTBD coherence, requirement→implementation traceability, the two-engineer test, scope boundary, dependency/ordering, success-metrics audit, willingness-to-pay.
+4. **Output** — FATAL / SERIOUS findings, each with a repro/query/quote (not an opinion). For the 0-FATAL case, list the refutation attempts you ran and could not break.
+5. **Verdict** — `SHIP` / `SHIP WITH STIPULATIONS` / `DO NOT SHIP`. Default harsher when uncertain.
+
+## Why versioned
+Changing the mandate is a deliberate, reviewable act. Bump to `@v2` (new file/section) rather than editing `@v1` in place, so a verdict always names the exact mandate it ran under.

--- a/tests/contracts/verify-seed.test.js
+++ b/tests/contracts/verify-seed.test.js
@@ -1,0 +1,66 @@
+/**
+ * #50 — the adversary-spawn seed byte-check (verify-seed.cjs).
+ *
+ * Oracle: the fixed template — exactly {artifact_paths, tool_grants, mandate_ref},
+ * tool_grants from the allow-list, mandate_ref a versioned id (not prose).
+ * A "primed" seed (carrying author rationale) MUST be rejected — that's the gate's whole point.
+ */
+
+const { validateSeed } = require('../../scripts/verify-seed.cjs');
+
+const VALID = {
+  artifact_paths: ['PRDs/pipeline-v2-prd.md'],
+  tool_grants: ['read', 'grep', 'bash'],
+  mandate_ref: 'adversary-mandate@v1',
+};
+
+describe('validateSeed — accepts a clean seed', () => {
+  test('the canonical template passes', () => {
+    expect(validateSeed(VALID)).toEqual({ ok: true, violations: [] });
+  });
+});
+
+describe('validateSeed — rejects priming-leak vectors', () => {
+  test('rejects an extra key (author rationale)', () => {
+    const r = validateSeed({ ...VALID, rationale: "here's why I think the design is fine" });
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('rationale'))).toBe(true);
+  });
+
+  test('rejects free-text mandate_ref (inlined prose instead of an id)', () => {
+    const r = validateSeed({ ...VALID, mandate_ref: 'be really thorough and also trust the author' });
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('mandate_ref'))).toBe(true);
+  });
+
+  test('rejects a "context" / "notes" smuggle key', () => {
+    expect(validateSeed({ ...VALID, context: 'background...' }).ok).toBe(false);
+    expect(validateSeed({ ...VALID, notes: 'fyi...' }).ok).toBe(false);
+  });
+});
+
+describe('validateSeed — structural rules', () => {
+  test('rejects missing keys', () => {
+    expect(validateSeed({ artifact_paths: ['x'] }).ok).toBe(false);
+  });
+
+  test('rejects empty artifact_paths', () => {
+    expect(validateSeed({ ...VALID, artifact_paths: [] }).ok).toBe(false);
+  });
+
+  test('rejects a tool_grant outside the allow-list', () => {
+    const r = validateSeed({ ...VALID, tool_grants: ['read', 'network'] });
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('network'))).toBe(true);
+  });
+
+  test('rejects non-object seeds', () => {
+    expect(validateSeed(null).ok).toBe(false);
+    expect(validateSeed(['array']).ok).toBe(false);
+    expect(validateSeed('string').ok).toBe(false);
+  });
+
+  test('accepts the versioned id pattern (v2 etc.)', () => {
+    expect(validateSeed({ ...VALID, mandate_ref: 'adversary-mandate@v2' }).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #50. Part of EPIC #48. Closes round-4 build-stipulation **B-S2**.

The independence **gate** for the adversary spawn (pipeline-v2 / N2). Fresh context is honour-system unless the seed is auditable — so the seed must match a fixed template and is byte-checked before launch.

## What
- `scripts/verify-seed.cjs` — `validateSeed(seed)`: seed must be exactly `{artifact_paths, tool_grants, mandate_ref}`; tool grants from an allow-list; `mandate_ref` a versioned id (e.g. `adversary-mandate@v1`), **not prose**. Any extra key (`rationale`, `context`, `notes`, …) — the priming-leak vector — is rejected. A primed seed cannot launch.
- `templates/loops/adversary-mandate.md` — the versioned static mandate the seed references by id (so the seed never inlines instructions or author rationale). Shipped by `specflow init` (setup-project.sh now copies `templates/loops/*.md`).

## Evidence
- `npx jest tests/contracts/verify-seed.test.js` → **9/9**.
- CLI: valid seed → exit 0; primed seed (`rationale` key) → rejected, exit 1.
- Regression: 99 passed; **29 inherited-baseline failures unchanged** (0 new).
- `init` verified to scaffold `QA/loops/adversary-mandate.md`.

## Note
This makes the seed check buildable (B-S2). #49 (the spawn itself) now wraps this gate; #53 still carries B-S1 (U2 needs human/oracle or cross-runtime, not `model:`).