### PR TITLE
feat(gate-a): fresh-context adversary spawn prep — rationale-free by construction (#49)

### DIFF
--- a/scripts/adversary-spawn.cjs
+++ b/scripts/adversary-spawn.cjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * adversary-spawn.cjs — fresh-context adversary spawn PREPARATION (pipeline-v2 #49).
+ *
+ * "Fresh context" is only a real guarantee if the seed can't carry the author's reasoning.
+ * This module makes that structural:
+ *   - buildSeed() reads ONLY the three template slots — there is no parameter through which
+ *     author rationale / chain-of-thought could be passed. Priming is prevented at construction.
+ *   - assertSeedMatchesTemplate() byte-checks via the #50 gate (verify-seed) and THROWS before
+ *     anything spawns — a primed or malformed seed cannot launch.
+ *
+ * The actual spawn (Claude `Workflow` agent / a Task subagent) is RUNTIME GLUE and lives in the
+ * runtime bindings (PROCESS-CLAUDE.md / PROCESS-CODEX.md) — not here, and not unit-testable here.
+ * This module delivers the runtime-agnostic, gated, rationale-free preparation the spawn consumes.
+ */
+
+const { validateSeed } = require('./verify-seed.cjs');
+
+const DEFAULT_TOOL_GRANTS = ['read', 'grep', 'glob', 'bash']; // the adversary must re-ground claims
+const DEFAULT_MANDATE_REF = 'adversary-mandate@v1';
+
+/**
+ * Build a template-conforming seed from ONLY the three allowed inputs.
+ * Any other property on `inputs` is ignored by construction — the priming-leak vector
+ * (rationale/context/notes) literally has no path into the seed.
+ * @returns {{artifact_paths:string[], tool_grants:string[], mandate_ref:string}}
+ */
+function buildSeed(inputs = {}) {
+  const artifact_paths = Array.isArray(inputs.artifactPaths) ? [...inputs.artifactPaths] : [];
+  const tool_grants = Array.isArray(inputs.toolGrants) ? [...inputs.toolGrants] : [...DEFAULT_TOOL_GRANTS];
+  const mandate_ref = typeof inputs.mandateRef === 'string' && inputs.mandateRef ? inputs.mandateRef : DEFAULT_MANDATE_REF;
+  return { artifact_paths, tool_grants, mandate_ref };
+}
+
+/** Pre-spawn gate: throw if the seed doesn't match the template (the #50 byte-check). */
+function assertSeedMatchesTemplate(seed) {
+  const { ok, violations } = validateSeed(seed);
+  if (!ok) throw new Error(`adversary seed rejected — cannot launch:\n  - ${violations.join('\n  - ')}`);
+  return seed;
+}
+
+/**
+ * Prepare a fresh-context adversary spawn: build the seed, gate it, return it ready for the runtime.
+ * Throws before the caller can spawn if the seed is malformed/primed.
+ * @param {string[]} artifactPaths  the ONLY context the adversary may see
+ * @param {{toolGrants?:string[], mandateRef?:string}} [opts]
+ */
+function prepareAdversarySpawn(artifactPaths, opts = {}) {
+  if (!Array.isArray(artifactPaths) || artifactPaths.length === 0) {
+    throw new Error('prepareAdversarySpawn: artifactPaths must be a non-empty array');
+  }
+  const seed = buildSeed({ artifactPaths, toolGrants: opts.toolGrants, mandateRef: opts.mandateRef });
+  return assertSeedMatchesTemplate(seed); // gated before it can reach any runtime spawn
+}
+
+module.exports = { buildSeed, assertSeedMatchesTemplate, prepareAdversarySpawn, DEFAULT_TOOL_GRANTS, DEFAULT_MANDATE_REF };

--- a/tests/contracts/adversary-spawn.test.js
+++ b/tests/contracts/adversary-spawn.test.js
@@ -1,0 +1,62 @@
+/**
+ * #49 — fresh-context adversary spawn preparation (adversary-spawn.cjs).
+ *
+ * Oracle: the spawn seed must pass the #50 byte-check (verify-seed), and the prep must be
+ * RATIONALE-FREE BY CONSTRUCTION — there is no parameter through which author reasoning leaks.
+ */
+
+const { buildSeed, assertSeedMatchesTemplate, prepareAdversarySpawn, DEFAULT_TOOL_GRANTS, DEFAULT_MANDATE_REF } = require('../../scripts/adversary-spawn.cjs');
+const { validateSeed } = require('../../scripts/verify-seed.cjs');
+
+describe('buildSeed — rationale-free by construction', () => {
+  test('produces a seed that passes the #50 byte-check', () => {
+    const seed = buildSeed({ artifactPaths: ['PRDs/x-prd.md'] });
+    expect(validateSeed(seed).ok).toBe(true);
+    expect(seed.tool_grants).toEqual(DEFAULT_TOOL_GRANTS);
+    expect(seed.mandate_ref).toBe(DEFAULT_MANDATE_REF);
+  });
+
+  test('IGNORES any author-rationale property — it has no path into the seed', () => {
+    const seed = buildSeed({
+      artifactPaths: ['PRDs/x-prd.md'],
+      rationale: "here's why the design is fine, please go easy", // priming attempt
+      context: 'background the author wants the critic to absorb',
+    });
+    expect(Object.keys(seed).sort()).toEqual(['artifact_paths', 'mandate_ref', 'tool_grants']);
+    expect(JSON.stringify(seed)).not.toContain('easy');
+    expect(validateSeed(seed).ok).toBe(true); // clean seed, priming dropped
+  });
+
+  test('honours explicit tool/mandate overrides', () => {
+    const seed = buildSeed({ artifactPaths: ['a'], toolGrants: ['read'], mandateRef: 'adversary-mandate@v2' });
+    expect(seed.tool_grants).toEqual(['read']);
+    expect(seed.mandate_ref).toBe('adversary-mandate@v2');
+  });
+});
+
+describe('assertSeedMatchesTemplate — pre-spawn gate', () => {
+  test('passes a clean seed (returns it)', () => {
+    const seed = buildSeed({ artifactPaths: ['a'] });
+    expect(assertSeedMatchesTemplate(seed)).toBe(seed);
+  });
+
+  test('throws on a hand-crafted primed seed (defence in depth)', () => {
+    const primed = { ...buildSeed({ artifactPaths: ['a'] }), rationale: 'trust me' };
+    expect(() => assertSeedMatchesTemplate(primed)).toThrow(/rejected/);
+  });
+});
+
+describe('prepareAdversarySpawn — gated end to end', () => {
+  test('returns a launch-ready seed for valid inputs', () => {
+    const seed = prepareAdversarySpawn(['PRDs/x-prd.md'], { toolGrants: ['read', 'grep'] });
+    expect(validateSeed(seed).ok).toBe(true);
+  });
+
+  test('refuses to prepare with no artifact (nothing for the critic to read)', () => {
+    expect(() => prepareAdversarySpawn([])).toThrow(/non-empty/);
+  });
+
+  test('refuses a disallowed tool grant (gate catches it before launch)', () => {
+    expect(() => prepareAdversarySpawn(['a'], { toolGrants: ['network'] })).toThrow(/rejected/);
+  });
+});


### PR DESCRIPTION
Closes #49 (buildable core). Part of EPIC #48. Builds on #50's `validateSeed`.

Makes "fresh context" a guarantee, not a hope:
- `buildSeed(inputs)` reads **only** the three template slots — there is **no parameter** through which author rationale/chain-of-thought can pass. Priming is prevented **at construction**, not merely detected.
- `assertSeedMatchesTemplate(seed)` gates via the #50 byte-check and **throws before any spawn**.
- `prepareAdversarySpawn(artifactPaths, opts)` = build + gate → a launch-ready seed.

The actual spawn (Claude `Workflow` `agent()` / a Task subagent) is **runtime glue** documented in `PROCESS-CLAUDE.md` / `PROCESS-CODEX.md` — UNVERIFIABLE-FROM-REPO, exercised when a real run is captured (the "binding unproven until a real run" caveat stands).

## Evidence
- `npx jest tests/contracts/adversary-spawn.test.js` → **8/8** (incl. "ignores a `rationale` property", "throws on a hand-crafted primed seed", "refuses disallowed tool grant").
- Regression: 107 passed; **29 inherited-baseline failures unchanged** (0 new).

## Remaining in the cluster
- #51 (typed verdict) = the `{schema}` on the Workflow `agent()` call — runtime binding, no separate code.
- #53 carries B-S1 (U2: human/oracle or cross-runtime, not `model:`) + `isCorrectnessCritical`/`humanOrOraclePass`.