### PR TITLE
feat(gate-d): persona-walk integration gate + hop tables at GATE A + hardening rules (#60)

### DIFF
--- a/agents/contract-test-generator.md
+++ b/agents/contract-test-generator.md
@@ -498,3 +498,7 @@ npm test -- contracts (runs at build time)
        ↓
 CI blocks merge on failure
 ```
+
+## Assertion identity rule (pipeline-hardening #60)
+
+Generated assertions must key on **stable identities** — entity/domain id, stable name, or type multiset — **never on per-call-generated ids** (run-minted UUIDs, auto-increments, ephemeral DOM ids). A generated test that can only target a per-call id should emit a `data-testid` requirement for the implementation instead of a weakened assertion.

--- a/agents/journey-tester.md
+++ b/agents/journey-tester.md
@@ -285,3 +285,7 @@ tests/
 - [ ] Steps use test.step() for clear reporting
 - [ ] Cross-session auth handled correctly
 - [ ] Failure at step N correctly reports root cause
+
+## Assertion identity rule (pipeline-hardening #60)
+
+**Never key an assertion on a per-call-generated id** (row ids, UUIDs minted during the run, auto-increment values) — they differ every run and force the test to either flake or assert nothing. Key on a **stable identity**: the entity's domain id, its stable name, or the **type multiset** (e.g. "the room set contains {Baby Room, Wobblers, Preschool}" — compare by name, not by `droppable-room-tile` ids that carry no room identity). If the only available key is per-call, that is a missing-testid finding against the implementation, not a reason to weaken the assertion.

--- a/scripts/teardown-gate.cjs
+++ b/scripts/teardown-gate.cjs
@@ -21,7 +21,15 @@
  *    Exit 0 = pass, 1 = gate fails, 2 = usage/IO error.
  *
  * Journeys are recognised by id lines like `- J: <id> — <purpose>` (map) and `## J: <id>` or
- * `- J: <id>` (findings). Evidence refs = any `evidence/<name>.png` mention in the entry.
+ * `- J: <id>` (findings). Evidence refs = any `evidence/<name>.(png|jpg|jpeg|webp|txt|json)`
+ * mention in the entry — text/JSON included so value-bearing hops can attach the oracle
+ * re-read output itself (GATE D, pipeline-hardening #60), not just a screenshot.
+ *
+ * 3. CHECK-SIGN (generic, single-file):
+ *      node scripts/teardown-gate.cjs check-sign <file>
+ *    Validates one hash-bound sign-off (exists, parses, hash matches, has signer).
+ *    Used by GATE_A for the falsification PASS binding and by GATE D for hop-table
+ *    amendments — same sign/check pattern, any artifact. Exit 0 = valid, 1 = invalid.
  */
 
 const { createHash } = require('crypto');
@@ -81,8 +89,8 @@ function check(dir) {
     const sections = findContent.split(/^#+\s*J:/m).slice(1);
     sections.forEach(sec => {
       const id = (sec.match(/^\s*([A-Za-z0-9][A-Za-z0-9_-]*)/) || [])[1] || '?';
-      const refs = [...sec.matchAll(/evidence\/[\w./-]+\.(?:png|jpg|jpeg|webp)/g)].map(m => m[0]);
-      if (refs.length === 0) errs.push(`no evidence: findings for ${id} reference no evidence/*.png — "I walked it" is not evidence`);
+      const refs = [...sec.matchAll(/evidence\/[\w./-]+\.(?:png|jpg|jpeg|webp|txt|json)/g)].map(m => m[0]);
+      if (refs.length === 0) errs.push(`no evidence: findings for ${id} reference no evidence/* file (png/jpg/webp/txt/json) — "I walked it" is not evidence`);
       for (const r of refs) if (!existsSync(join(dir, r))) errs.push(`dangling evidence: ${r} referenced for ${id} but file does not exist`);
     });
   } else if (existsSync(map)) {
@@ -111,8 +119,13 @@ if (require.main === module) {
     sign(target, by);
   } else if (cmd === 'check' && target) {
     check(target);
+  } else if (cmd === 'check-sign' && target) {
+    const err = checkSignoff(target);
+    if (err) { console.error(`✗ ${err}`); process.exit(1); }
+    console.error(`✓ valid sign-off for ${basename(target)} (hash matches current content)`);
+    process.exit(0);
   } else {
-    console.error('Usage: teardown-gate.cjs sign <file> --by "<name>" | check <teardown-dir>');
+    console.error('Usage: teardown-gate.cjs sign <file> --by "<name>" | check <teardown-dir> | check-sign <file>');
     process.exit(2);
   }
 }

--- a/templates/loops/feature-build.yaml
+++ b/templates/loops/feature-build.yaml
@@ -3,7 +3,9 @@
 # LOCATE the current rail from the branch + CI state, advance ONE rail, persist, stop/escalate.
 loop: feature-build
 process_ref: PROCESS.md#step-6-7
-principle: you and any swarm are muscle; trust lives ONLY in GATE C (branch-protected CI vs real data).
+principle: you and any swarm are muscle; per-slice trust lives ONLY in GATE C (branch-protected
+  CI vs real data); EPIC-level trust lives in GATE D (epic_gate below) — a slice's contract test
+  is necessary but not sufficient; the gate of record is the persona walk on the merged tree.
 
 progress_display:             # EMIT this at the START of every tick so the human sees the rail
   rule: >
@@ -32,16 +34,24 @@ preconditions:
   - constraint: slice < 1000 lines (else propose a 4–8 slice split)
 
 rails:                        # advance one per tick, in order
-  - id: 1_ticket    gate: ticket + ACs + journey id confirmed
-  - id: 2_contract  gate: contract YAML stub → full (steps + selectors from catalogue)
-  - id: 3_e2e       gate: real-backend e2e test runs against a real seeded backend
-  - id: 4_oracle    gate: every asserted number traced to the live calc / real source (never guessed)
-  - id: 5_impl      gate: smallest mergeable slice (<1000 lines) makes it pass
+  - id: 1_ticket
+    gate: ticket + ACs + journey id confirmed
+  - id: 2_contract
+    gate: contract YAML stub → full (steps + selectors from catalogue)
+  - id: 3_e2e
+    gate: real-backend e2e test runs against a real seeded backend
+  - id: 4_oracle
+    gate: every asserted number traced to the live calc / real source (never guessed)
+  - id: 5_impl
+    gate: smallest mergeable slice (<1000 lines) makes it pass
 
 muscle:                       # do work, never approve it
   - /qa (coverage + regression) — run + SPOT-CHECK before trusting
   - multicheck REVIEWER (different model) for complex slices
   - ruflo swarm — only if triggered (>1500 lines, 3+ layers, security/invariant-critical, rejected-unsure, new pattern)
+  - db_serialization: >
+      parallel AUTHORING is fine; DB VERIFICATION is serial — one verification slot,
+      claimed in the epic checklist before any e2e run (non-teams path; teams keep db-coordinator)
 
 GATE_C:                       # HARD, unfakeable — the only trust gate
   type: hard
@@ -50,7 +60,9 @@ GATE_C:                       # HARD, unfakeable — the only trust gate
 
 repair:
   classify: [coverage, regression, contract, journey, lint, flake]
-  inherited_baseline: not yours — note the tracking ticket, never silent --no-verify
+  inherited_baseline: >
+    not yours — but PROVE it before claiming it: run the failing test on the BASE branch first;
+    only a base-branch red may be classified inherited. File the tracking ticket. Never silent --no-verify.
   budget: 3 attempts/rail, 2 full passes
   on_exhausted: escalate with classified failure + last diff
 
@@ -60,3 +72,46 @@ never_without_human: [git push, open PR, merge, --no-verify, override contract]
 done_when:
   - 5 rails complete, muscle run + spot-checked, GATE C green, evidence note complete
   - STOP at "branch ready for review" — human opens the PR
+  - NOTE (slice-done ≠ epic-done): the EPIC is not done until GATE D (epic_gate below) is green.
+
+merge_notes:                  # stacked branches
+  - squash-merging a stacked branch DUPLICATES the base slice's commits in the next PR's diff;
+    escape = merge-commit (no squash) for stacks, or rebase the stack after each squash lands.
+
+# ============================================================================
+# epic_gate: GATE D — the persona-walk INTEGRATION gate (pipeline-hardening #60)
+# ============================================================================
+# GUARD: this section is NOT a rail. Per-issue feature-build ticks IGNORE it — their
+# done_when fires before slices merge, so no per-issue instance can ever reach this.
+# GATE D is ITS OWN INVOCATION: "Run GATE D for epic #N" (prompts/gate-d.prompt.md),
+# fired by the epic runner when a wave/epic's slices have merged.
+epic_gate:
+  id: GATE_D
+  type: hard                  # for EPIC-done — slices still merge on GATE C alone
+  why: >
+    Epics slice vertically; coherence bugs live horizontally where slices share a surface.
+    Per-slice green is structurally blind to seams — the walk tests along the axis the
+    decomposition cut across. (Worked example: timebreez #673 — 3 cross-slice oracle
+    conflicts on /my-leave and /dashboard, invisible to 22/22-green GATE C runs.)
+  trigger: per wave when waves merge to main, else per epic-close (U2)
+  env: the same real seeded backend tier GATE C names — never a mock
+  do: >
+    A SCOPED TEARDOWN RUN against merged main: journey map := the hop tables
+    (PRDs/<slug>-hops.md, pinned at GATE A) + the seam-derived hops (GATE B; seams
+    RECOMPUTED here from final ticket state). The gate-d prompt MATERIALIZES the hop
+    artifact into teardown format (each hop a "- J:" entry; findings per hop; evidence
+    per finding) so teardown-gate.cjs check validates it unchanged.
+  evidence: >
+    every hop has a findings entry referencing evidence files that exist; VALUE-BEARING
+    hops must attach the oracle re-read output itself (.txt/.json or a screenshot showing
+    the value) — a decorative screenshot does not satisfy a value hop.
+  disposition: >               # closes the ungoverned-reconciliation loophole (PR #724 exhibit)
+    a red hop MUST be dispositioned `bug` or `stale-oracle`. stale-oracle = an amendment to
+    PRDs/<slug>-hops.md requiring HUMAN COUNTERSIGN (teardown-gate.cjs sign) — the build
+    agent can never reconcile its own oracle. On `bug`: the LAST-MERGED writer of the seam
+    reopens (it changed already-walked state); the failure names the seam pair + tiebreak.
+    Shared-module case: the disposition names the module commit, not page blame.
+  proof: >
+    teardown-gate.cjs check passes on the gate-d dir AND the human signs map + result
+    (2 sign actions). The epic cannot close without this signed artifact.
+  never_without_human: [sign, stale-oracle amendment, closing the epic on a red GATE D]

--- a/templates/loops/prompts/gate-d.prompt.md
+++ b/templates/loops/prompts/gate-d.prompt.md
@@ -1,0 +1,24 @@
+# gate-d invocation prompt (template)
+
+One per wave/epic, fired **after that wave/epic's slices have merged** (per-issue feature-build runs end before merge — this is its own invocation). Run in the code repo against merged main.
+
+```
+Goal:   GATE D green for epic #<n> — persona-walk the MERGED tree; epic cannot close until signed
+Path:   QA/loops/feature-build.yaml → epic_gate (GATE_D)
+Inputs: { epic: <n>, hops: PRDs/<slug>-hops.md, env: <the same real seeded backend tier GATE C names> }
+
+Follow the epic_gate spec — do not restate it. The run:
+1. RECOMPUTE seams from final ticket state (writes/reads declarations); journey map :=
+   the hop tables + seam-derived hops, MATERIALIZED into teardown format under
+   gate-d/<epic>/ (each hop a "- J:" entry; findings per hop; evidence per finding).
+2. Walk every hop against merged main on the named env. Value-bearing hops attach the
+   oracle re-read output itself (.txt/.json or a screenshot showing the value) —
+   a decorative screenshot does not satisfy a value hop.
+3. Every red hop gets a DISPOSITION: `bug` (the last-merged writer of the seam reopens;
+   name the seam pair + tiebreak; shared-module case names the module commit) or
+   `stale-oracle` (an amendment to the hops artifact — REQUIRES HUMAN COUNTERSIGN;
+   you may never reconcile your own oracle).
+4. PROOF: `node scripts/teardown-gate.cjs check gate-d/<epic>/` must pass, and the human
+   signs map + result. STOP and present for signing — never sign yourself, never close
+   the epic on a red or unsigned GATE D.
+```

--- a/templates/loops/spec-build.yaml
+++ b/templates/loops/spec-build.yaml
@@ -25,6 +25,7 @@ inputs:                       # supplied by the invocation, not hard-coded here
 state:                        # where 'where am I?' is read from — durable, never chat
   prd: PRDs/${slug}-prd.md
   verdict_artifact: PRDs/${slug}-verdict.md
+  hops_artifact: PRDs/${slug}-hops.md   # pre-committed integration oracle (GATE A output, consumed by GATE D)
   tickets: gh issues labelled ${slug}
 
 stages:
@@ -48,8 +49,17 @@ stages:
     do_until: verdict issued; fix each FATAL/SERIOUS in the document, re-review
   - id: GATE_A               # HARD — the trust gate
     type: hard
-    gate: verdict ∈ {SHIP, SHIP_WITH_STIPULATIONS} written to ${verdict_artifact}
-    rule: no ticket-writing until SHIP; then human approval before issues are created
+    gate: >
+      verdict ∈ {SHIP, SHIP_WITH_STIPULATIONS} written to ${verdict_artifact}
+      AND ${hops_artifact} exists with per-persona hop tables:
+      From → URL → required control → EXPECTED VALUE (re-read) → oracle/source.
+      A pre-committed integration oracle, pinned BEFORE code exists (post-hoc tests get
+      unconsciously shaped to pass). Assertion bar = a re-read value, never element presence.
+    rule: >
+      no ticket-writing until SHIP; then human approval before issues are created.
+      The hops artifact is HUMAN-SIGNED at pin time (teardown-gate.cjs sign); post-SHIP
+      changes only via countersigned amendment — never unilaterally by the build agent
+      (it is the party the oracle constrains). Consumed by GATE D (feature-build epic_gate).
   - id: tickets
     do: specflow-writer → issues (Gherkin ACs, data-testids, contract refs, e2e filename)
     gate: every UI story references a journey contract; Gherkin lives once in the catalogue

--- a/tests/contracts/teardown-gate.test.js
+++ b/tests/contracts/teardown-gate.test.js
@@ -75,3 +75,36 @@ describe('teardown-gate', () => {
     expect(run(['check', dir])).toBe(1);
   });
 });
+
+describe('teardown-gate — GATE D extensions (#60)', () => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'td-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test('value-bearing evidence: .json/.txt oracle output satisfies the evidence check', () => {
+    mkdirSync(join(dir, 'evidence'), { recursive: true });
+    writeFileSync(join(dir, 'evidence/balance-query.json'), '{"balance":"20 days"}');
+    writeFileSync(join(dir, 'journey-map.md'), '- J: HOP1 — balance re-read on /my-leave\n');
+    writeFileSync(join(dir, 'findings.md'), '## J: HOP1\nVerdict: WORKS\nevidence/balance-query.json\n');
+    run(['sign', join(dir, 'journey-map.md'), '--by', 'Colm'], dir);
+    expect(run(['check', dir])).toBe(0);
+  });
+
+  test('dangling .json evidence still fails (existence is checked for text artifacts too)', () => {
+    mkdirSync(join(dir, 'evidence'), { recursive: true });
+    writeFileSync(join(dir, 'journey-map.md'), '- J: HOP1 — x\n');
+    writeFileSync(join(dir, 'findings.md'), '## J: HOP1\nevidence/missing.json\n');
+    run(['sign', join(dir, 'journey-map.md'), '--by', 'Colm'], dir);
+    expect(run(['check', dir])).toBe(1);
+  });
+
+  test('check-sign: valid sign-off → 0; edit-after-sign → 1; no sign-off → 1', () => {
+    const f = join(dir, 'pipeline-hardening-prd.md');
+    writeFileSync(f, '# PRD v1\n');
+    expect(run(['check-sign', f])).toBe(1);               // unsigned
+    run(['sign', f, '--by', 'Colm'], dir);
+    expect(run(['check-sign', f])).toBe(0);               // valid
+    writeFileSync(f, '# PRD v1 — edited after PASS\n');
+    expect(run(['check-sign', f])).toBe(1);               // stale (the falsify stale-PASS hole)
+  });
+});


### PR DESCRIPTION
Closes #60. Part of EPIC #59. Built from the SHIPped PRD (gmh-docs `PRDs/pipeline-hardening-prd.md`, 2-round two-lens Gate A) + the #60 correction comment.

## What
- **`epic_gate:` (GATE D)** in `feature-build.yaml` — its own invocation (`prompts/gate-d.prompt.md`), NOT a rail (per-issue runs die pre-merge); scoped teardown run vs merged main; hard for epic-done; guard comment so per-issue ticks ignore it.
- **Hop tables at GATE A** (`spec-build.yaml`) — `PRDs/<slug>-hops.md`, From → URL → control → **expected value (re-read)** → oracle; human-signed at pin; countersigned amendments only.
- **Disposition rule** — red hop = `bug` (last-merged writer reopens, seam pair named; shared-module names the commit) or `stale-oracle` (human countersign). The agent can never reconcile its own oracle — closes the ungoverned-reconciliation loophole (exhibit: timebreez PR #724).
- **`teardown-gate.cjs`**: evidence regex now accepts `.txt/.json` (value-bearing hops attach the oracle re-read itself); new **`check-sign <file>`** subcommand (generic single-file sign-off validation — also used by #62's hash-bound PASS).
- **Hardening rules**: inherited-baseline *proof* (base-branch run first); DB verification slot; stacked-merge note; stable-key assertion rule in `journey-tester.md` + `contract-test-generator.md`.
- **Drive-by fix**: `feature-build.yaml` rails were invalid YAML since creation (`key: value` inside a plain scalar) — restructured to block style; file now parses.

## Evidence
- `npx jest tests/contracts/teardown-gate.test.js` → **9/9** (3 new: json evidence accepted, dangling json fails, check-sign valid→0 / edited-after-sign→1 / unsigned→1 — the stale-PASS hole, proven closed at CLI).
- Full suite: branch **687 pass / 29 fail** vs main **684 / 29** → +3 mine, **0 new failures** — **baseline proven by running the suite on main**, per the very rule this PR introduces.
- Both edited YAMLs parse (js-yaml).

## Out of scope / follow-ups
- `daily-use-teardown.yaml` has a **pre-existing** parse error (116:50) — inherited, not touched here; flagged on #59.
- #62 (mandate@v2 + falsification template) and #61 (seam script) build next, in that order.