### PR TITLE
feat(falsify): adversary-mandate@v2 + falsification artifact gating GATE_A (#62)

### DIFF
--- a/scripts/verify-falsification.cjs
+++ b/scripts/verify-falsification.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * verify-falsification.cjs — model-free structural gate for a falsification artifact
+ * (adversary-mandate@v2 / pipeline-hardening #62).
+ *
+ * GATE_A must not trust that PRDs/<slug>-falsification.md is complete — it checks. This verifies
+ * the artifact has every required section, non-empty, and a recognized final verdict. It does NOT
+ * judge content quality (that's the critic's job) — it stops a STUB from satisfying the gate.
+ * Pair with `teardown-gate.cjs check-sign <prd>` for the hash-bound PASS binding.
+ *
+ * Usage:  node scripts/verify-falsification.cjs <falsification.md>
+ * Exit 0 = structurally complete, 1 = incomplete/invalid, 2 = usage/IO error.
+ */
+
+const { readFileSync, existsSync } = require('fs');
+
+const REQUIRED = [
+  'Premise Attack',
+  'Claim Inventory',
+  'Dependency Audit',
+  'Acceptance Gate Attack',
+  'Source / Reality Ledger',
+  'Overclaim / Scope Leakage',
+  'Banned-Mode Self-Check',
+  'Final Verdict',
+];
+const VERDICTS = ['PASS WITH STIPULATIONS', 'PASS', 'FAIL']; // longest first for matching
+
+/** Pure. @returns {{ok:boolean, violations:string[]}} */
+function validateFalsification(content) {
+  const v = [];
+  // Split into sections by H2 headings; map heading text → body.
+  const parts = content.split(/^##\s+/m).slice(1);
+  const sections = new Map();
+  for (const p of parts) {
+    const nl = p.indexOf('\n');
+    const heading = (nl === -1 ? p : p.slice(0, nl)).trim();
+    const body = (nl === -1 ? '' : p.slice(nl + 1)).trim();
+    sections.set(heading, body);
+  }
+
+  for (const req of REQUIRED) {
+    if (!sections.has(req)) { v.push(`missing section: "## ${req}"`); continue; }
+    if (req === 'Final Verdict') {
+      const final = sections.get(req).toUpperCase();
+      if (!VERDICTS.some(verd => final.includes(verd))) {
+        v.push('Final Verdict has no recognized verdict (PASS / PASS WITH STIPULATIONS / FAIL)');
+      }
+      continue;
+    }
+    // Every other section is table-based: "filled" = a table with a header AND ≥1 data row,
+    // i.e. >1 non-separator `|` row. Header+separator only (the template stub) fails.
+    const lines = sections.get(req).split('\n').map(l => l.trim()).filter(Boolean);
+    const nonSeparatorTableRows = lines.filter(l => l.startsWith('|') && !/^\|[\s|:.-]+\|?$/.test(l));
+    if (nonSeparatorTableRows.length <= 1) {
+      v.push(`empty section: "## ${req}" has only a header row — falsify, don't stub`);
+    }
+  }
+
+  return { ok: v.length === 0, violations: v };
+}
+
+function main(argv) {
+  const path = argv[2];
+  if (!path) { console.error('Usage: node scripts/verify-falsification.cjs <falsification.md>'); process.exit(2); }
+  if (!existsSync(path)) { console.error(`✗ no such file: ${path} — GATE_A requires the falsification artifact`); process.exit(2); }
+  const { ok, violations } = validateFalsification(readFileSync(path, 'utf8'));
+  if (ok) { console.error('✓ falsification artifact structurally complete'); process.exit(0); }
+  console.error('✗ falsification artifact incomplete:');
+  for (const m of violations) console.error(`  - ${m}`);
+  process.exit(1);
+}
+
+module.exports = { validateFalsification, REQUIRED };
+
+if (require.main === module) main(process.argv);

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -120,7 +120,7 @@ echo ""
 echo -e "${BLUE}[4/10]${NC} Copying scripts and examples..."
 
 # Scripts
-for script in specflow-compile.cjs verify-graph.cjs verify-ticket-journey.cjs verify-seed.cjs adversary-spawn.cjs teardown-gate.cjs; do
+for script in specflow-compile.cjs verify-graph.cjs verify-ticket-journey.cjs verify-seed.cjs adversary-spawn.cjs teardown-gate.cjs verify-falsification.cjs; do
   if [ -f "$SCRIPT_DIR/scripts/$script" ]; then
     cp "$SCRIPT_DIR/scripts/$script" "$TARGET_DIR/scripts/"
     echo -e "${GREEN}✓${NC} scripts/$script"

--- a/templates/loops/adversary-mandate.md
+++ b/templates/loops/adversary-mandate.md
@@ -14,3 +14,27 @@ You are a hostile, independent critic. You did not write the artifact and have n
 
 ## Why versioned
 Changing the mandate is a deliberate, reviewable act. Bump to `@v2` (new file/section) rather than editing `@v1` in place, so a verdict always names the exact mandate it ran under.
+
+---
+
+# adversary-mandate@v2
+
+Supersedes @v1 for spec-build. Everything in @v1 holds, **plus a required falsification artifact** and the structure to produce it well. (Folds pipeline-v2's "falsify" idea into the one critic — no second standing critic.)
+
+## Added in v2
+
+6. **Falsification artifact (required output).** Beyond the verdict, write `PRDs/<slug>-falsification.md` from `falsification-template.md`. Run the falsification **like the persona lens — as a parallel, fresh-context sub-run** that *informs* the single verdict; do not bundle it into the structural pass's depth budget (depth dies when bundled).
+7. **Typed claim inventory.** Every load-bearing claim classified: `definition | assumption | theorem | impl-choice | hypothesis | citation`, with its source, whether it's load-bearing, and — if wrong — what downstream artifact breaks.
+8. **Dependency audit.** No dependency edge asserted without a one-line reason. Attack blanket "X underlies everything" claims.
+9. **Corrections applied, not noted.** A finding recorded only in chat does not count. Each FATAL/SERIOUS is either fixed in the PRD or recorded as an owned stipulation in the verdict.
+10. **Hash-bound PASS.** The falsification PASS is bound to the PRD content via `teardown-gate.cjs sign` on the PRD; GATE_A recomputes (`check-sign`) — a PRD edited after PASS fails until re-falsified. A non-substantive edit (typo) needs a human re-sign, not a full re-falsification.
+
+## Banned failure modes (each disqualifies a PASS)
+
+- **blanket dependency** — "X underlies everything" without per-claim proof.
+- **definition-as-assumption** — treating a property *being tested* as assumed true.
+- **source laundering** — a citation named only in chat treated as verified.
+- **nearby-proof** — a result sits near another and is treated as dependent on it.
+- **green-by-assertion** — "tests pass" with no independent oracle.
+- **inventory-as-reliance** — a source listed for future reading treated as already used.
+- **unapplied correction** — a defect noted in prose but never patched into the artifact.

--- a/templates/loops/falsification-template.md
+++ b/templates/loops/falsification-template.md
@@ -1,0 +1,42 @@
+# Falsification Pass — <slug>
+
+Required output of adversary-mandate@v2 (spec-build). Do not polish or summarize — **falsify**: ask not "is this clear?" but "how can it be false while still sounding clear?" Findings recorded only in chat do not count. Every table below must carry ≥1 data row (`verify-falsification.cjs` rejects a stub); GATE_A additionally requires a hash-bound PASS (`teardown-gate.cjs check-sign` on the PRD). Claim `Type` ∈ {definition, assumption, theorem, impl-choice, hypothesis, citation}. The Dependency Audit asserts no edge without a one-line reason.
+
+## Premise Attack
+| Premise | Source | Could be false because | Verdict | Required correction |
+|---|---|---|---|---|
+
+## Claim Inventory
+| Claim | Type | Source support | Load-bearing? | Status | What breaks downstream if wrong | Correction |
+|---|---|---|---|---|---|---|
+
+## Dependency Audit
+| Edge (A → B) | Reason edge exists | False-edge risk | Verdict | Correction |
+|---|---|---|---|---|
+
+## Acceptance Gate Attack
+| Gate | How it could be gamed | Missing oracle | Correction |
+|---|---|---|---|
+
+## Source / Reality Ledger
+| Concrete claim | Verified against (file:line / query) | Holds? | Evidence |
+|---|---|---|---|
+
+## Overclaim / Scope Leakage
+| Text | Why it overclaims | Replacement text |
+|---|---|---|
+
+## Banned-Mode Self-Check
+Each disqualifies a PASS. Mark present? + evidence for each.
+| Banned mode | Present? | Evidence / note |
+|---|---|---|
+| blanket dependency | | |
+| definition-as-assumption | | |
+| source laundering | | |
+| nearby-proof | | |
+| green-by-assertion | | |
+| inventory-as-reliance | | |
+| unapplied correction | | |
+
+## Final Verdict
+`PASS` / `PASS WITH STIPULATIONS` / `FAIL` — one line, then any owned stipulations (each with an owner).

--- a/templates/loops/spec-build.yaml
+++ b/templates/loops/spec-build.yaml
@@ -35,9 +35,15 @@ stages:
   - id: draft
     do: writer → ${prd}
     gate: JTBD, scope boundary, acceptance, success metrics, deps all present
-  - id: adversary            # one hostile critic, informed by parallel lenses
-    do: adversarial-prd-reviewer — 7-pass rubric + Special Mandate
+  - id: adversary            # one hostile critic (adversary-mandate@v2), informed by parallel lenses
+    do: adversarial-prd-reviewer @v2 — 7-pass rubric + Special Mandate
         (reality-grounding ledger over every repo/schema claim; loophole hunt)
+    falsify_subrun: |         # @v2 added output — runs like the persona lens: PARALLEL, fresh-context
+      A fresh-context falsification sub-run (NOT bundled into the structural pass's depth budget)
+      tries to DISPROVE the premise, typed claim inventory, dependency graph, acceptance gates,
+      and source claims. It writes PRDs/${slug}-falsification.md (from falsification-template.md);
+      corrections are APPLIED to the PRD or recorded as owned stipulations in the verdict — chat
+      doesn't count. The 7 banned modes each disqualify a PASS. Informs the single verdict.
     persona_lens: |           # runs IN PARALLEL with the structural review — first persona touch
       A fresh-context persona/simulation lens walks real personas through the PRD's
       journeys ON PAPER ("can a human actually do this?") and returns CRITICAL design
@@ -55,6 +61,10 @@ stages:
       From → URL → required control → EXPECTED VALUE (re-read) → oracle/source.
       A pre-committed integration oracle, pinned BEFORE code exists (post-hoc tests get
       unconsciously shaped to pass). Assertion bar = a re-read value, never element presence.
+      AND PRDs/${slug}-falsification.md exists, passes `verify-falsification.cjs` (every
+      section filled, recognized verdict), and its PASS is HASH-BOUND to the current PRD —
+      `teardown-gate.cjs check-sign ${prd}` must be green (a PRD edited after PASS fails
+      until re-falsified; a typo-only edit needs a human re-sign, not full re-falsification).
     rule: >
       no ticket-writing until SHIP; then human approval before issues are created.
       The hops artifact is HUMAN-SIGNED at pin time (teardown-gate.cjs sign); post-SHIP

--- a/tests/contracts/verify-falsification.test.js
+++ b/tests/contracts/verify-falsification.test.js
@@ -1,0 +1,57 @@
+/**
+ * verify-falsification.cjs — structural gate for the falsification artifact (#62).
+ * Oracle: the shipped template (templates/loops/falsification-template.md) is a STUB and must
+ * FAIL; a filled artifact must PASS; missing sections / missing verdict must FAIL.
+ */
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+const { validateFalsification, REQUIRED } = require('../../scripts/verify-falsification.cjs');
+
+const TEMPLATE = join(__dirname, '../../templates/loops/falsification-template.md');
+
+// A minimal FILLED artifact: every table section has ≥1 data row + a verdict.
+function filled() {
+  const row = '| x | y | z | w | v | u | t |';
+  return [
+    '## Premise Attack', '| P | S | could be false | FAIL | fix |', '|---|---|---|---|---|', row,
+    '## Claim Inventory', row, '|---|---|---|---|---|---|---|', row,
+    '## Dependency Audit', '| A→B | reason | risk | ok | - |', '|---|---|---|---|---|', row,
+    '## Acceptance Gate Attack', '| g | gamed | oracle | fix |', '|---|---|---|---|', row,
+    '## Source / Reality Ledger', '| claim | file:1 | yes | quote |', '|---|---|---|---|', row,
+    '## Overclaim / Scope Leakage', '| text | why | replace |', '|---|---|---|', row,
+    '## Banned-Mode Self-Check', '| blanket dependency | no | - |', '|---|---|---|', '| nearby-proof | no | - |',
+    '## Final Verdict', 'PASS WITH STIPULATIONS — owner: Colm',
+  ].join('\n');
+}
+
+describe('validateFalsification', () => {
+  test('the shipped template is a stub → REJECTED (empty table sections)', () => {
+    const r = validateFalsification(readFileSync(TEMPLATE, 'utf8'));
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('empty section'))).toBe(true);
+  });
+
+  test('a filled artifact → PASS', () => {
+    expect(validateFalsification(filled())).toEqual({ ok: true, violations: [] });
+  });
+
+  test('missing a required section → REJECTED naming it', () => {
+    const doc = filled().replace('## Dependency Audit', '## Something Else');
+    const r = validateFalsification(doc);
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('Dependency Audit'))).toBe(true);
+  });
+
+  test('no recognized verdict → REJECTED', () => {
+    const doc = filled().replace('PASS WITH STIPULATIONS — owner: Colm', 'looks good to me');
+    const r = validateFalsification(doc);
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('Final Verdict'))).toBe(true);
+  });
+
+  test('all 8 required sections are present in the shipped template', () => {
+    const content = readFileSync(TEMPLATE, 'utf8');
+    for (const req of REQUIRED) expect(content).toContain(`## ${req}`);
+  });
+});


### PR DESCRIPTION
Closes #62. Part of EPIC #59. Built off fresh main after #60 merged (avoided the spec-build.yaml GATE_A conflict). From the SHIPped PRD + the #62 correction comment.

## What
- **adversary-mandate@v2** (appended to `adversary-mandate.md`, not editing v1 — per the file's own versioning rule): adds the required falsification artifact, the **parallel fresh-context sub-run** (informs the one verdict — no second standing critic, resolving the F3 fold), typed claim inventory, dependency audit, corrections-applied rule, hash-bound PASS, and the 7 banned modes.
- **`falsification-template.md`** — 8 sections, table-uniform so completeness is checkable.
- **`verify-falsification.cjs`** — model-free structural gate: every section filled (a stub of the template is REJECTED), recognized final verdict. Stops a stub from satisfying GATE_A; does not judge content (that's the critic's job).
- **GATE_A** (`spec-build.yaml`) now also requires: `verify-falsification` PASS **AND** `teardown-gate.cjs check-sign <prd>` (PASS hash-bound to the PRD — a post-PASS edit fails until re-falsified; typo edits need a human re-sign). Reuses #60's `check-sign`.
- `init` scaffolds the new script + template.

## Evidence
- `npx jest tests/contracts/verify-falsification.test.js` → **5/5** (the shipped template is correctly REJECTED as a stub; a filled artifact passes; missing section / missing verdict fail).
- #60's teardown-gate tests still 9/9 (14/14 together).
- Full suite **693/29** vs main **687/29** → +tests mine, **0 new failures**; 29 inherited-baseline confirmed unchanged.
- `init` verified to scaffold `verify-falsification.cjs` + `falsification-template.md`.

## Next
- #61 (seam script) builds last — off fresh main after this merges (it also touches spec-build.yaml + adds a sibling script).