### PR TITLE
feat(seam-lite): declare writes/reads → compute seams at GATE B → derived hops (#61)

### DIFF
--- a/scripts/verify-seams.cjs
+++ b/scripts/verify-seams.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * verify-seams.cjs — seam-lite: compute integration seams from per-ticket surface declarations
+ * (pipeline-hardening #61). Sibling of verify-ticket-journey.cjs; does NOT fork verify-graph.cjs.
+ *
+ * Epics slice vertically; coherence bugs live horizontally where slices share a surface. This
+ * computes those seams mechanically so GATE D's walk hops are DERIVED, not remembered, and a
+ * later seam failure names its owning slices.
+ *
+ * A "surface" is a route literal or a data-testid value, EXACTLY as it appears in code. Each
+ * ticket declares which surfaces it `writes` and which it `reads`. A seam is a pair of slices
+ * that touch the same surface where ≥1 writes it:
+ *   - writer × writer  (both change it — classic collision, e.g. #681↔#686 on /my-leave)
+ *   - writer × reader  (one changes what another depends on — rename/shape break)
+ *
+ * Honesty rule: every declared surface MUST resolve in the repo (grep). A surface that matches
+ * nothing is an ERROR, not a silently-dropped seam — that was the whole "zero seams" failure mode.
+ *
+ * Usage:
+ *   node scripts/verify-seams.cjs <tickets.json> [--repo-root .]      (resolve surfaces in repo)
+ *   node scripts/verify-seams.cjs <tickets.json> --no-resolve         (skip repo grep; testing)
+ * tickets.json: [{ id, writes: [surface...], reads: [surface...] }]
+ * Exit 0 = computed clean, 1 = unresolved surface(s), 2 = usage/IO error.
+ * Prints the seam list + derived hops as JSON to stdout (consumed by GATE D prep).
+ */
+
+const { readFileSync, existsSync, readdirSync, statSync } = require('fs');
+const { join } = require('path');
+
+/**
+ * Pure seam computation. No IO.
+ * @param {Array<{id:string, writes?:string[], reads?:string[]}>} tickets
+ * @returns {{seams: Array<{surface, writers:string[], readers:string[], pairs:string[][], kind}>, derivedHops: object[]}}
+ */
+function computeSeams(tickets) {
+  const bySurface = new Map(); // surface → { writers:Set, readers:Set }
+  for (const t of tickets) {
+    for (const s of t.writes || []) {
+      if (!bySurface.has(s)) bySurface.set(s, { writers: new Set(), readers: new Set() });
+      bySurface.get(s).writers.add(t.id);
+    }
+    for (const s of t.reads || []) {
+      if (!bySurface.has(s)) bySurface.set(s, { writers: new Set(), readers: new Set() });
+      bySurface.get(s).readers.add(t.id);
+    }
+  }
+
+  const seams = [];
+  for (const [surface, { writers, readers }] of bySurface) {
+    const W = [...writers].sort();
+    const R = [...readers].filter(r => !writers.has(r)).sort(); // reader-only
+    // A seam needs ≥1 writer AND ≥1 other slice (another writer, or a reader) on the surface.
+    const others = W.length + R.length;
+    if (W.length === 0 || others < 2) continue;
+    const pairs = [];
+    for (let i = 0; i < W.length; i++) {
+      for (let j = i + 1; j < W.length; j++) pairs.push([W[i], W[j]]); // writer×writer
+      for (const r of R) pairs.push([W[i], r]);                       // writer×reader
+    }
+    const kind = R.length === 0 ? 'writer-writer' : (W.length === 1 ? 'writer-reader' : 'mixed');
+    seams.push({ surface, writers: W, readers: R, pairs, kind });
+  }
+  seams.sort((a, b) => a.surface.localeCompare(b.surface));
+
+  // Derived must-have hops: one per seam surface — GATE D must walk it and re-read its value.
+  const derivedHops = seams.map(s => ({
+    surface: s.surface,
+    why: `seam (${s.kind}) between ${[...new Set(s.pairs.flat())].join(', ')}`,
+    assert: 're-read value on the merged tree — not element presence',
+  }));
+
+  return { seams, derivedHops };
+}
+
+/** Does `surface` (a route literal or data-testid) appear anywhere under root? */
+function surfaceResolves(surface, root) {
+  const needle = surface.replace(/^\//, ''); // route or testid substring
+  const SKIP = new Set(['node_modules', '.git', 'dist', 'build', 'coverage', '.next']);
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      if (e.isDirectory()) { if (!SKIP.has(e.name)) stack.push(join(dir, e.name)); continue; }
+      if (!/\.(tsx?|jsx?|vue|svelte|html|cjs|mjs)$/.test(e.name)) continue;
+      try { if (readFileSync(join(dir, e.name), 'utf8').includes(needle)) return true; } catch { /* skip */ }
+    }
+  }
+  return false;
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const path = args.find(a => !a.startsWith('--'));
+  if (!path) { console.error('Usage: node scripts/verify-seams.cjs <tickets.json> [--repo-root .] [--no-resolve]'); process.exit(2); }
+  let tickets;
+  try { tickets = JSON.parse(readFileSync(path, 'utf8')); } catch (e) { console.error(`✗ ${e.message}`); process.exit(2); }
+
+  const resolve = !args.includes('--no-resolve');
+  const rootIdx = args.indexOf('--repo-root');
+  const root = rootIdx !== -1 ? args[rootIdx + 1] : '.';
+
+  if (resolve) {
+    const declared = new Set();
+    for (const t of tickets) { (t.writes || []).forEach(s => declared.add(s)); (t.reads || []).forEach(s => declared.add(s)); }
+    const unresolved = [...declared].filter(s => !surfaceResolves(s, root));
+    if (unresolved.length) {
+      console.error('✗ declared surfaces not found in repo (declare them exactly as they appear in code):');
+      for (const s of unresolved) console.error(`  - ${s}`);
+      process.exit(1);
+    }
+  }
+
+  const { seams, derivedHops } = computeSeams(tickets);
+  console.error(`seam-lite: ${seams.length} seam(s) across ${tickets.length} tickets`);
+  for (const s of seams) console.error(`  ⚠ ${s.surface} — ${s.kind}: ${s.pairs.map(p => p.join('↔')).join(', ')}`);
+  process.stdout.write(JSON.stringify({ seams, derivedHops }, null, 2) + '\n');
+  process.exit(0);
+}
+
+module.exports = { computeSeams, surfaceResolves };
+
+if (require.main === module) main(process.argv);

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -120,7 +120,7 @@ echo ""
 echo -e "${BLUE}[4/10]${NC} Copying scripts and examples..."
 
 # Scripts
-for script in specflow-compile.cjs verify-graph.cjs verify-ticket-journey.cjs verify-seed.cjs adversary-spawn.cjs teardown-gate.cjs verify-falsification.cjs; do
+for script in specflow-compile.cjs verify-graph.cjs verify-ticket-journey.cjs verify-seed.cjs adversary-spawn.cjs teardown-gate.cjs verify-falsification.cjs verify-seams.cjs; do
   if [ -f "$SCRIPT_DIR/scripts/$script" ]; then
     cp "$SCRIPT_DIR/scripts/$script" "$TARGET_DIR/scripts/"
     echo -e "${GREEN}✓${NC} scripts/$script"

--- a/templates/loops/spec-build.yaml
+++ b/templates/loops/spec-build.yaml
@@ -73,10 +73,20 @@ stages:
   - id: tickets
     do: specflow-writer → issues (Gherkin ACs, data-testids, contract refs, e2e filename)
     gate: every UI story references a journey contract; Gherkin lives once in the catalogue
+    declares: |             # seam-lite (#61): each ticket declares the surfaces it touches
+      writes: [<surface>...]   # surfaces this slice CHANGES (route literal or data-testid, EXACTLY as in code)
+      reads:  [<surface>...]   # surfaces this slice DEPENDS ON
   - id: GATE_B               # soft
     type: soft
-    do: board-auditor + specflow-uplifter — wire every ticket to journey + test + contract
-    gate: requirement→journey→test→issue complete; no orphans; no duplicate IDs
+    do: >
+      board-auditor + specflow-uplifter — wire every ticket to journey + test + contract.
+      PLUS seam-lite: `verify-seams.cjs <tickets.json> --repo-root .` computes the seam graph
+      (writer×writer AND writer×reader pairs on shared surfaces) and ERRORS on any declared
+      surface not found in the repo (no silent zero-seam runs). Derived hops are appended to
+      ${hops_artifact} — the integration walk is DERIVED from seams, not remembered.
+    gate: >
+      requirement→journey→test→issue complete; no orphans; no duplicate IDs;
+      all declared surfaces resolve; seam-derived hops written to ${hops_artifact}.
   - id: GATE_B5              # soft — SECOND persona touch (first ran at the adversary stage)
     type: soft
     do: pre-flight-simulator — walk real personas through each TICKET before code.

--- a/tests/contracts/verify-seams.test.js
+++ b/tests/contracts/verify-seams.test.js
@@ -1,0 +1,67 @@
+/**
+ * verify-seams.cjs — seam-lite computation (#61).
+ * Oracle: the timebreez #673 collisions — #681 & #686 both write /my-leave (writer×writer);
+ * a reader on a written surface is a writer×reader seam; an isolated surface is no seam.
+ */
+
+const { computeSeams } = require('../../scripts/verify-seams.cjs');
+
+describe('computeSeams', () => {
+  test('writer×writer: two slices writing one surface is a seam naming both', () => {
+    const { seams } = computeSeams([
+      { id: '681', writes: ['/my-leave'] },
+      { id: '686', writes: ['/my-leave'] },
+    ]);
+    expect(seams).toHaveLength(1);
+    expect(seams[0].surface).toBe('/my-leave');
+    expect(seams[0].kind).toBe('writer-writer');
+    expect(seams[0].pairs).toEqual([['681', '686']]);
+  });
+
+  test('writer×reader: a reader on a written surface is a seam (rename/shape break)', () => {
+    const { seams } = computeSeams([
+      { id: '685', writes: ['data-balance-card'] },
+      { id: '687', reads: ['data-balance-card'] },
+    ]);
+    expect(seams).toHaveLength(1);
+    expect(seams[0].kind).toBe('writer-reader');
+    expect(seams[0].pairs).toEqual([['685', '687']]);
+  });
+
+  test('no seam: a surface only one slice touches', () => {
+    const { seams } = computeSeams([
+      { id: '683', writes: ['/presence'] },
+      { id: '684', writes: ['/settings'] },
+    ]);
+    expect(seams).toHaveLength(0);
+  });
+
+  test('reader-only surface (no writer) is NOT a seam — nothing can break it', () => {
+    const { seams } = computeSeams([
+      { id: 'a', reads: ['/dashboard'] },
+      { id: 'b', reads: ['/dashboard'] },
+    ]);
+    expect(seams).toHaveLength(0);
+  });
+
+  test('derived hops: one per seam, asserting a re-read value', () => {
+    const { derivedHops } = computeSeams([
+      { id: '681', writes: ['/my-leave'] },
+      { id: '686', writes: ['/my-leave'], reads: ['/dashboard'] },
+      { id: '685', writes: ['/dashboard'] },
+    ]);
+    const surfaces = derivedHops.map(h => h.surface).sort();
+    expect(surfaces).toEqual(['/dashboard', '/my-leave']);
+    expect(derivedHops.every(h => /re-read value/.test(h.assert))).toBe(true);
+  });
+
+  test('mixed: 2 writers + a reader on one surface enumerates all pairs', () => {
+    const { seams } = computeSeams([
+      { id: 'w1', writes: ['/x'] },
+      { id: 'w2', writes: ['/x'] },
+      { id: 'r1', reads: ['/x'] },
+    ]);
+    expect(seams[0].kind).toBe('mixed');
+    expect(seams[0].pairs.sort()).toEqual([['w1', 'r1'], ['w1', 'w2'], ['w2', 'r1']].sort());
+  });
+});


### PR DESCRIPTION
Closes #61. **Last slice of EPIC #59.** Built off fresh main after #62 merged.

## What
- **`verify-seams.cjs`** — model-free, sibling of `verify-ticket-journey.cjs` (no fork of `verify-graph.cjs`). Tickets declare `writes:[]/reads:[]` surfaces (route literal or `data-testid`, exactly as in code). Computes seams = shared surfaces with ≥1 writer: **writer×writer** (collision) and **writer×reader** (rename/shape break). **Errors on any declared surface not found in the repo** — kills the silent zero-seam hole. Emits derived hops (assert a re-read value) → appended to the hops artifact → consumed by GATE D.
- **`spec-build.yaml`**: tickets stage gains the `writes/reads` declaration; GATE B runs `verify-seams` + writes seam-derived hops to `${hops_artifact}`.
- Lightweight per the scope guard — no graph/incremental-build framework. `init` scaffolds the script.

## Evidence
- `npx jest tests/contracts/verify-seams.test.js` → **6/6**, oracle-anchored to the timebreez #673 collisions (#681↔#686 on /my-leave = writer×writer; a reader on a written surface = writer×reader; reader-only = no seam).
- CLI: unknown surface → ERROR exit 1; `--no-resolve` computes seams exit 0.
- Full suite **700/29** vs main **687/29** → +6 mine, **0 new failures**; 29 inherited-baseline unchanged.

## EPIC #59 — complete after this merges
#60 (GATE D + hop tables + hardening) ✅ · #62 (falsify @v2) ✅ · #61 (seam-lite) ← this. All three pipeline-hardening changes shipped; pinned hop tables + computed seams + GATE D close the seam-bug class the worked example surfaced.