### PR TITLE
feat(adr): conditional ADR-conformance + universal reuse check (#68)

### DIFF
--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -73,6 +73,10 @@ Replace placeholders in [brackets] with your project-specific information.
 **Board CLI:** [gh | jira | linear | other] (must be installed and authenticated)
 **Tech Stack:** [e.g., React + Vite + Tailwind, Supabase, Vercel]
 **Primary Focus:** [e.g., Scheduling SaaS for childcare providers]
+<!-- OPTIONAL: if your project uses Architecture Decision Records, point here.
+     When set (or auto-detected at docs/adr|adrs|ard|architecture/decisions/), GATE B requires
+     tickets to cite a resolving ADR + declare component reuse (verify-adr.cjs). Omit if unused. -->
+**ADR Location:** [e.g., docs/adr/ — or leave blank if you don't use ADRs]
 
 <!-- If this section is empty, Claude MUST ask the user for context before proceeding -->
 

--- a/scripts/verify-adr.cjs
+++ b/scripts/verify-adr.cjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * verify-adr.cjs — CONDITIONAL ADR-conformance + component-reuse gate (#68).
+ * Sibling of verify-seams.cjs / verify-ticket-journey.cjs; does NOT fork verify-graph.cjs.
+ *
+ * Not all repos use ADRs — so this DETECTS an ADR folder and EXITS 0 SILENTLY when there isn't one.
+ * When there IS one, each ticket must be built UNDER the decisions and by REUSING existing
+ * components, not reinventing:
+ *   - cite ≥1 ADR id that RESOLVES to a file in the ADR dir   (or `adr: none — <reason>`)
+ *   - declare `reuses: [...]`                                  (or `new: <component> — <reason>`)
+ * A cited ADR id that resolves to no file is an ERROR (no phantom citations — same honesty rule
+ * as seam-lite's unresolved surfaces).
+ *
+ * Usage:
+ *   node scripts/verify-adr.cjs <tickets.json> [--repo-root .] [--adr-dir <path>]
+ * tickets.json: [{ id, adrs?:[ids], reuses?:[components], adrNone?:"reason", newComponent?:"reason" }]
+ * Exit 0 = pass (incl. "no ADR dir → skip"), 1 = violations, 2 = usage/IO error.
+ */
+
+const { readFileSync, existsSync, readdirSync, statSync } = require('fs');
+const { join } = require('path');
+
+const KNOWN_ADR_DIRS = ['docs/adr', 'docs/adrs', 'docs/ard', 'docs/architecture/decisions', 'docs/architecture', 'adr', 'architecture/decisions'];
+
+/** Normalize any ADR reference/filename to `ADR-<int>` (so ADR-006 ≡ ADR-6 ≡ 0006-foo.md). Pure. */
+function normalizeAdrId(s) {
+  const m = String(s).match(/(\d+)/);
+  return m ? `ADR-${parseInt(m[1], 10)}` : null;
+}
+
+/** Extract an ADR id from a filename like ADR-006-foo.md or 0007-use-x.md. Pure. Returns null if none. */
+function adrIdFromFilename(name) {
+  if (/^adr[-_]?\d+/i.test(name) || /^\d{1,4}[-_]/.test(name)) return normalizeAdrId(name);
+  return null;
+}
+
+/**
+ * The audit. Pure — no IO.
+ * @param {Set<string>} adrIds  normalized ADR ids present in the repo (empty Set ⇒ caller decided to enforce with none, treat as no-dir? caller guards)
+ * @param {Array} tickets       [{id, adrs?, reuses?, adrNone?, newComponent?}]
+ * @returns {{ok:boolean, violations:string[]}}
+ */
+function auditAdrCompliance(adrIds, tickets) {
+  const v = [];
+  for (const t of tickets) {
+    const cited = (t.adrs || []).map(normalizeAdrId).filter(Boolean);
+    const phantom = cited.filter(id => !adrIds.has(id));
+    if (phantom.length) v.push(`ticket ${t.id}: cites ADR id(s) with no matching file: ${phantom.join(', ')}`);
+    if (cited.length === 0 && !t.adrNone) {
+      v.push(`ticket ${t.id}: no ADR cited and no "adr: none — <reason>" — this repo has ADRs; build under one`);
+    }
+    const reuses = t.reuses || [];
+    if (reuses.length === 0 && !t.newComponent) {
+      v.push(`ticket ${t.id}: no reuse declared and no "new: <component> — <reason>" — reuse existing components or justify a new one`);
+    }
+  }
+  return { ok: v.length === 0, violations: v };
+}
+
+/** Find an ADR dir (configured wins; else first known dir that exists and holds ≥1 ADR-ish .md). IO. */
+function detectAdrDir(root, configured) {
+  const candidates = configured ? [configured, ...KNOWN_ADR_DIRS] : KNOWN_ADR_DIRS;
+  for (const rel of candidates) {
+    const abs = join(root, rel);
+    if (!existsSync(abs) || !statSync(abs).isDirectory()) continue;
+    const mds = readdirSync(abs).filter(f => f.endsWith('.md'));
+    if (mds.some(adrIdFromFilename)) return abs;
+  }
+  return null;
+}
+
+/** ADR ids present in a dir. IO. */
+function adrIdsInDir(dir) {
+  const ids = new Set();
+  for (const f of readdirSync(dir)) {
+    const id = adrIdFromFilename(f);
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const path = args.find(a => !a.startsWith('--'));
+  if (!path) { console.error('Usage: node scripts/verify-adr.cjs <tickets.json> [--repo-root .] [--adr-dir <path>]'); process.exit(2); }
+  const root = args.includes('--repo-root') ? args[args.indexOf('--repo-root') + 1] : '.';
+  const configured = args.includes('--adr-dir') ? args[args.indexOf('--adr-dir') + 1] : null;
+
+  const dir = detectAdrDir(root, configured);
+  if (!dir) { console.error('verify-adr: no ADR folder detected — skipping (this repo does not use ADRs)'); process.exit(0); }
+
+  let tickets;
+  try { tickets = JSON.parse(readFileSync(path, 'utf8')); } catch (e) { console.error(`✗ ${e.message}`); process.exit(2); }
+  const adrIds = adrIdsInDir(dir);
+  const { ok, violations } = auditAdrCompliance(adrIds, tickets);
+  console.error(`verify-adr: ${adrIds.size} ADR(s) in ${dir}, ${tickets.length} ticket(s) checked`);
+  if (ok) { console.error('✓ every ticket cites a resolving ADR (or justified none) and declares reuse'); process.exit(0); }
+  console.error('✗ ADR-conformance gate FAILED:');
+  for (const m of violations) console.error(`  - ${m}`);
+  process.exit(1);
+}
+
+module.exports = { normalizeAdrId, adrIdFromFilename, auditAdrCompliance, detectAdrDir, adrIdsInDir };
+
+if (require.main === module) main(process.argv);

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -120,7 +120,7 @@ echo ""
 echo -e "${BLUE}[4/10]${NC} Copying scripts and examples..."
 
 # Scripts
-for script in specflow-compile.cjs verify-graph.cjs verify-ticket-journey.cjs verify-seed.cjs adversary-spawn.cjs teardown-gate.cjs verify-falsification.cjs verify-seams.cjs; do
+for script in specflow-compile.cjs verify-graph.cjs verify-ticket-journey.cjs verify-seed.cjs adversary-spawn.cjs teardown-gate.cjs verify-falsification.cjs verify-seams.cjs verify-adr.cjs; do
   if [ -f "$SCRIPT_DIR/scripts/$script" ]; then
     cp "$SCRIPT_DIR/scripts/$script" "$TARGET_DIR/scripts/"
     echo -e "${GREEN}✓${NC} scripts/$script"

--- a/templates/loops/adversary-mandate.md
+++ b/templates/loops/adversary-mandate.md
@@ -38,3 +38,14 @@ Supersedes @v1 for spec-build. Everything in @v1 holds, **plus a required falsif
 - **green-by-assertion** — "tests pass" with no independent oracle.
 - **inventory-as-reliance** — a source listed for future reading treated as already used.
 - **unapplied correction** — a defect noted in prose but never patched into the artifact.
+
+---
+
+# adversary-mandate@v3
+
+Supersedes @v2 for spec-build. Everything in @v2 holds, **plus reuse-don't-reinvent + conditional ADR conformance** (the generalization of the v1 catch that flagged a duplicated existing validator).
+
+## Added in v3
+
+11. **Reuse check (universal).** For every component/module/script the PRD proposes to build, ask: **does this already exist?** Name the existing thing it should reuse, or justify the new one (and if it's an architectural decision, propose a new ADR). Reinventing an existing component is a FATAL.
+12. **ADR conformance (conditional — only if the repo has an ADR folder).** If `docs/adr|adrs|ard|architecture/decisions/` (or a CLAUDE.md `ADR Location`) exists: every ticket must be built **under** the relevant ADR(s) — cite a resolving ADR id, or carry `adr: none — <reason>` — and the PRD must **conform** to those ADRs (flag any silent violation). A cited ADR id that resolves to no file is a FATAL (phantom citation). If there is no ADR folder, this clause is a no-op — do not invent one.

--- a/templates/loops/spec-build.yaml
+++ b/templates/loops/spec-build.yaml
@@ -73,9 +73,12 @@ stages:
   - id: tickets
     do: specflow-writer → issues (Gherkin ACs, data-testids, contract refs, e2e filename)
     gate: every UI story references a journey contract; Gherkin lives once in the catalogue
-    declares: |             # seam-lite (#61): each ticket declares the surfaces it touches
-      writes: [<surface>...]   # surfaces this slice CHANGES (route literal or data-testid, EXACTLY as in code)
+    declares: |             # per-ticket declarations consumed by the gates below
+      writes: [<surface>...]   # seam-lite (#61): surfaces this slice CHANGES (route/data-testid, EXACTLY as in code)
       reads:  [<surface>...]   # surfaces this slice DEPENDS ON
+      reuses: [<component>...]  # ADR/reuse (#68): existing components this slice builds on
+      adrs:   [ADR-NNN...]      # the decisions it's built under  (or `adrNone: "<reason>"`)
+                                # only enforced if the repo has an ADR folder — else ignored
   - id: GATE_B               # soft
     type: soft
     do: >
@@ -84,9 +87,13 @@ stages:
       (writer×writer AND writer×reader pairs on shared surfaces) and ERRORS on any declared
       surface not found in the repo (no silent zero-seam runs). Derived hops are appended to
       ${hops_artifact} — the integration walk is DERIVED from seams, not remembered.
+      PLUS conditional ADR/reuse (#68): `verify-adr.cjs <tickets.json> --repo-root .` — if the
+      repo has an ADR folder, every ticket cites a RESOLVING ADR (or `adrNone`) and declares
+      `reuses` (or a justified new component); if there's no ADR folder it exits 0 silently.
     gate: >
       requirement→journey→test→issue complete; no orphans; no duplicate IDs;
-      all declared surfaces resolve; seam-derived hops written to ${hops_artifact}.
+      all declared surfaces resolve; seam-derived hops written to ${hops_artifact};
+      verify-adr passes (skipped automatically when the repo has no ADR folder).
   - id: GATE_B5              # soft — SECOND persona touch (first ran at the adversary stage)
     type: soft
     do: pre-flight-simulator — walk real personas through each TICKET before code.

--- a/tests/contracts/verify-adr.test.js
+++ b/tests/contracts/verify-adr.test.js
@@ -1,0 +1,79 @@
+/**
+ * verify-adr.cjs — conditional ADR-conformance + reuse gate (#68).
+ * Oracle: the gmh-docs convention (docs/ard/ADR-006-*.md → id "ADR-6"); ADR-006 ≡ ADR-6.
+ */
+
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('fs');
+const { join } = require('path');
+const { tmpdir } = require('os');
+const {
+  normalizeAdrId, adrIdFromFilename, auditAdrCompliance, detectAdrDir, adrIdsInDir,
+} = require('../../scripts/verify-adr.cjs');
+
+describe('id normalization', () => {
+  test('ADR-006, ADR-6, and 0006-foo.md all normalize to ADR-6', () => {
+    expect(normalizeAdrId('ADR-006')).toBe('ADR-6');
+    expect(normalizeAdrId('ADR-6')).toBe('ADR-6');
+    expect(adrIdFromFilename('ADR-006-entitlement-model.md')).toBe('ADR-6');
+    expect(adrIdFromFilename('0006-use-postgres.md')).toBe('ADR-6');
+  });
+  test('non-ADR filenames yield null', () => {
+    expect(adrIdFromFilename('README.md')).toBeNull();
+    expect(adrIdFromFilename('index.md')).toBeNull();
+  });
+});
+
+describe('auditAdrCompliance (pure)', () => {
+  const adrIds = new Set(['ADR-1', 'ADR-6']);
+
+  test('valid ticket: resolving ADR + reuse → pass', () => {
+    const r = auditAdrCompliance(adrIds, [{ id: '1', adrs: ['ADR-006'], reuses: ['BalanceCard'] }]);
+    expect(r).toEqual({ ok: true, violations: [] });
+  });
+
+  test('phantom citation: ADR id with no file → fail', () => {
+    const r = auditAdrCompliance(adrIds, [{ id: '1', adrs: ['ADR-99'], reuses: ['x'] }]);
+    expect(r.ok).toBe(false);
+    expect(r.violations.some(v => v.includes('no matching file') && v.includes('ADR-99'))).toBe(true);
+  });
+
+  test('no ADR cited and no justification → fail', () => {
+    const r = auditAdrCompliance(adrIds, [{ id: '1', reuses: ['x'] }]);
+    expect(r.violations.some(v => v.includes('no ADR cited'))).toBe(true);
+  });
+
+  test('explicit adr:none reason is accepted', () => {
+    const r = auditAdrCompliance(adrIds, [{ id: '1', adrNone: 'pure docs change', reuses: ['x'] }]);
+    expect(r.ok).toBe(true);
+  });
+
+  test('no reuse and no new-component justification → fail', () => {
+    const r = auditAdrCompliance(adrIds, [{ id: '1', adrs: ['ADR-1'] }]);
+    expect(r.violations.some(v => v.includes('no reuse declared'))).toBe(true);
+  });
+
+  test('justified new component is accepted', () => {
+    const r = auditAdrCompliance(adrIds, [{ id: '1', adrs: ['ADR-1'], newComponent: 'RolloverWidget — nothing like it exists' }]);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('detection (conditional skip)', () => {
+  let root;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'adr-')); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  test('no ADR dir → detectAdrDir returns null (caller skips)', () => {
+    expect(detectAdrDir(root, null)).toBeNull();
+  });
+
+  test('docs/ard with ADR files → detected, ids extracted', () => {
+    mkdirSync(join(root, 'docs/ard'), { recursive: true });
+    writeFileSync(join(root, 'docs/ard/ADR-001-x.md'), '# ADR 1');
+    writeFileSync(join(root, 'docs/ard/ADR-006-entitlement.md'), '# ADR 6');
+    writeFileSync(join(root, 'docs/ard/README.md'), 'index'); // ignored
+    const dir = detectAdrDir(root, null);
+    expect(dir).not.toBeNull();
+    expect([...adrIdsInDir(dir)].sort()).toEqual(['ADR-1', 'ADR-6']);
+  });
+});


### PR DESCRIPTION
Closes #68.

## What
- **`verify-adr.cjs`** — model-free, conditional. **Detects an ADR folder** (`docs/adr|adrs|ard|architecture/decisions`, or a CLAUDE.md `ADR Location`); **exits 0 silently if there isn't one** ("not all use it, but if they do you should"). When present: every ticket cites a **resolving** ADR id (or `adrNone: reason`) and declares `reuses` (or a justified `newComponent`); a phantom ADR citation is an ERROR (same honesty rule as seam-lite's unresolved surfaces). IDs normalize so `ADR-006 ≡ ADR-6 ≡ 0006-foo.md`.
- **adversary-mandate@v3** — (1) **universal reuse check**: reinventing an existing component is FATAL (generalizes the v1 catch that flagged a duplicated `verify-graph.cjs`); (2) **conditional ADR conformance**: when ADRs exist, the PRD must conform / tickets cite under them.
- **spec-build.yaml** — tickets declare `adrs`/`reuses` (sibling of #61's `writes/reads`); GATE B runs `verify-adr`.
- `init` scaffolds the script; `CLAUDE-MD-TEMPLATE.md` gains an optional **ADR Location** field.

## Evidence
- `npx jest tests/contracts/verify-adr.test.js` → **10/10**, oracle-anchored to the gmh-docs convention (`docs/ard/ADR-006-*.md` → `ADR-6`). Covers: no-dir → silent skip; dir detection + id extraction; phantom citation; missing ADR; `adrNone` accepted; missing reuse; justified new component.
- CLI: no ADR dir → exit 0 ("skipping").
- Full suite **711/29** vs main **700/29** → +11 mine, **0 new failures**; init verified to scaffold `verify-adr.cjs`.

## Design notes
- **Conditional by construction** — the no-ADR repo sees zero friction.
- MADR `NNNN-title.md` ids are supported via leading-number normalization; richer MADR metadata (status/supersedes) is out of scope (lightweight, per the same scope discipline as seam-lite).