### PR TITLE
Complete genuine looper runtime gates

### DIFF
--- a/bin/specflow.js
+++ b/bin/specflow.js
@@ -143,16 +143,44 @@ const COMMANDS = {
     },
   },
   provenance: {
-    usage: 'specflow provenance <provenance.json>',
+    usage: 'specflow provenance <provenance.json> [--diff file|--git-diff|--staged-diff]',
     desc: 'Verify source provenance evidence for a feature-build slice',
     run: (args) => {
       const file = args[0];
       if (!file) {
-        console.error('Usage: specflow provenance <provenance.json>');
+        console.error('Usage: specflow provenance <provenance.json> [--diff file|--git-diff|--staged-diff]');
         process.exit(2);
       }
       const script = resolve(SPECFLOW_ROOT, 'scripts', 'provenance-gate.cjs');
-      exec(`node "${script}" "${resolve(file)}"`);
+      const rest = args.slice(1).map((arg) => arg.startsWith('--') ? arg : `"${resolve(arg)}"`).join(' ');
+      exec(`node "${script}" "${resolve(file)}" ${rest}`);
+    },
+  },
+  'ci-status': {
+    usage: 'specflow ci-status <pr-number>',
+    desc: 'Read GitHub PR check status for Gate C triage',
+    run: (args) => {
+      const pr = args[0];
+      if (!pr || !/^\d+$/.test(pr)) {
+        console.error('Usage: specflow ci-status <pr-number>');
+        process.exit(2);
+      }
+      const raw = execSilent(`gh pr checks ${pr} --json name,state,conclusion,link`);
+      if (!raw) {
+        console.error(`Could not read PR #${pr} checks. Verify gh auth and repo context.`);
+        process.exit(1);
+      }
+      const checks = JSON.parse(raw);
+      const failing = checks.filter((check) => ['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED'].includes(String(check.conclusion || check.state || '').toUpperCase()));
+      const pending = checks.filter((check) => ['PENDING', 'QUEUED', 'IN_PROGRESS', 'WAITING'].includes(String(check.state || '').toUpperCase()));
+      console.log(JSON.stringify({
+        pr: Number(pr),
+        total: checks.length,
+        failing: failing.map((check) => ({ name: check.name, state: check.state, conclusion: check.conclusion, link: check.link })),
+        pending: pending.map((check) => ({ name: check.name, state: check.state, conclusion: check.conclusion, link: check.link })),
+        gate_c: failing.length ? 'red' : (pending.length ? 'pending' : 'green'),
+      }, null, 2));
+      if (failing.length) process.exit(1);
     },
   },
   'adapter-smoke': {
@@ -216,8 +244,9 @@ if (!command || command === 'help' || command === '--help' || command === '-h') 
   console.log('  npx @colmbyrne/specflow verify');
   console.log('  npx @colmbyrne/specflow audit 500');
   console.log('  npx @colmbyrne/specflow run spec-build --slug my-feature --goal "ready tickets" --input docs/idea.md');
-  console.log('  npx @colmbyrne/specflow provenance evidence/provenance-77-78-80.json');
+  console.log('  npx @colmbyrne/specflow provenance evidence/provenance-77-78-80.json --git-diff');
   console.log('  npx @colmbyrne/specflow adapter-smoke claude-print --dry-run');
+  console.log('  npx @colmbyrne/specflow ci-status 76');
   console.log('  npx @colmbyrne/specflow graph\n');
   process.exit(0);
 }

--- a/bin/specflow.js
+++ b/bin/specflow.js
@@ -3,7 +3,7 @@
 const { execSync } = require('child_process');
 const { resolve, dirname, join } = require('path');
 const { existsSync, readFileSync, writeFileSync, readdirSync } = require('fs');
-const { cli: runSpecflowLoop } = require('../scripts/specflow-runner.cjs');
+const { cli: runSpecflowLoop, planAdapterSmoke, runAdapter } = require('../scripts/specflow-runner.cjs');
 
 // Specflow root is one level up from bin/
 const SPECFLOW_ROOT = resolve(dirname(__filename), '..');
@@ -142,6 +142,36 @@ const COMMANDS = {
       if (code) process.exit(code);
     },
   },
+  provenance: {
+    usage: 'specflow provenance <provenance.json>',
+    desc: 'Verify source provenance evidence for a feature-build slice',
+    run: (args) => {
+      const file = args[0];
+      if (!file) {
+        console.error('Usage: specflow provenance <provenance.json>');
+        process.exit(2);
+      }
+      const script = resolve(SPECFLOW_ROOT, 'scripts', 'provenance-gate.cjs');
+      exec(`node "${script}" "${resolve(file)}"`);
+    },
+  },
+  'adapter-smoke': {
+    usage: 'specflow adapter-smoke <claude-print|codex-exec> [--live]',
+    desc: 'Plan or run an opt-in local adapter smoke check',
+    run: (args) => {
+      const provider = args[0];
+      if (!['claude-print', 'codex-exec'].includes(provider)) {
+        console.error('Usage: specflow adapter-smoke <claude-print|codex-exec> [--live]');
+        process.exit(2);
+      }
+      const smoke = planAdapterSmoke(provider, { live: args.includes('--live') });
+      console.log(JSON.stringify(smoke, null, 2));
+      if (!args.includes('--live')) return;
+      const result = runAdapter(smoke.policy, { owningGateCommand: 'adapter smoke only' });
+      console.log(JSON.stringify(result, null, 2));
+      if (!['gate_rerun_required', 'dry_run'].includes(result.status)) process.exit(1);
+    },
+  },
 };
 
 function exec(cmd) {
@@ -186,6 +216,8 @@ if (!command || command === 'help' || command === '--help' || command === '-h') 
   console.log('  npx @colmbyrne/specflow verify');
   console.log('  npx @colmbyrne/specflow audit 500');
   console.log('  npx @colmbyrne/specflow run spec-build --slug my-feature --goal "ready tickets" --input docs/idea.md');
+  console.log('  npx @colmbyrne/specflow provenance evidence/provenance-77-78-80.json');
+  console.log('  npx @colmbyrne/specflow adapter-smoke claude-print --dry-run');
   console.log('  npx @colmbyrne/specflow graph\n');
   process.exit(0);
 }

--- a/bin/specflow.js
+++ b/bin/specflow.js
@@ -165,19 +165,20 @@ const COMMANDS = {
         console.error('Usage: specflow ci-status <pr-number>');
         process.exit(2);
       }
-      const raw = execSilent(`gh pr checks ${pr} --json name,state,conclusion,link`);
+      const raw = execSilent(`gh pr view ${pr} --json statusCheckRollup`);
       if (!raw) {
         console.error(`Could not read PR #${pr} checks. Verify gh auth and repo context.`);
         process.exit(1);
       }
-      const checks = JSON.parse(raw);
-      const failing = checks.filter((check) => ['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED'].includes(String(check.conclusion || check.state || '').toUpperCase()));
-      const pending = checks.filter((check) => ['PENDING', 'QUEUED', 'IN_PROGRESS', 'WAITING'].includes(String(check.state || '').toUpperCase()));
+      const checks = JSON.parse(raw).statusCheckRollup || [];
+      const statusOf = (check) => String(check.conclusion || check.status || check.state || check.bucket || '').toUpperCase();
+      const failing = checks.filter((check) => ['FAILURE', 'FAIL', 'FAILING', 'ERROR', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED'].includes(statusOf(check)));
+      const pending = checks.filter((check) => ['PENDING', 'QUEUED', 'IN_PROGRESS', 'WAITING', 'REQUESTED'].includes(statusOf(check)));
       console.log(JSON.stringify({
         pr: Number(pr),
         total: checks.length,
-        failing: failing.map((check) => ({ name: check.name, state: check.state, conclusion: check.conclusion, link: check.link })),
-        pending: pending.map((check) => ({ name: check.name, state: check.state, conclusion: check.conclusion, link: check.link })),
+        failing: failing.map((check) => ({ name: check.name, status: statusOf(check), link: check.link || check.detailsUrl })),
+        pending: pending.map((check) => ({ name: check.name, status: statusOf(check), link: check.link || check.detailsUrl })),
         gate_c: failing.length ? 'red' : (pending.length ? 'pending' : 'green'),
       }, null, 2));
       if (failing.length) process.exit(1);

--- a/docs/specs/genuine-looper/adversary-review.md
+++ b/docs/specs/genuine-looper/adversary-review.md
@@ -1,0 +1,15 @@
+# Genuine Looper - Adversary Review
+
+## Findings
+
+| Severity | Finding | Disposition |
+|---|---|---|
+| SERIOUS | A loop runner that stops at every generative stage is still useful only if the prompt is materialized and resumable. | Added `GEN-ADAPTER-05` and `GEN-ADAPTER-06`. |
+| SERIOUS | Hardcoded stage maps will drift from YAML contracts. | Added `LOOP-RUNTIME-05`. |
+| SERIOUS | Provenance as JSON-only evidence does not catch literals newly inserted into code. | Added `PROVENANCE-02`. |
+| SERIOUS | Fresh codespaces can still miss installed loop assets and quietly degrade. | Added `INSTALL-LOOP-01`. |
+| P2 | Gate C readback may be impossible without GitHub auth. | Command reports auth failure and does not fake status. |
+
+## Verdict
+
+SHIP_WITH_STIPULATIONS. Implement as local CLI/runtime behavior only; do not claim hosted autonomous scheduling.

--- a/docs/specs/genuine-looper/contract.yml
+++ b/docs/specs/genuine-looper/contract.yml
@@ -1,0 +1,139 @@
+feature: genuine-looper
+requirements:
+  - id: REQ-LOOP-04
+    statement: Continue unblocked loop stages until a terminal condition or iteration budget.
+  - id: REQ-LOOP-05
+    statement: Derive executable stage order from loop YAML.
+  - id: REQ-GEN-05
+    statement: Materialize provider-ready stage prompts at generative stops.
+  - id: REQ-GEN-06
+    statement: Persist and resume provider session identifiers.
+  - id: REQ-GEN-07
+    statement: Provide opt-in live adapter smoke checks.
+  - id: REQ-PROV-02
+    statement: Audit changed code and tests for provenance risks after implementation.
+  - id: REQ-GATEC-01
+    statement: Read PR check status for Gate C triage.
+  - id: REQ-LOOP-06
+    statement: Report run status from durable contract and ledger state.
+  - id: REQ-INSTALL-01
+    statement: Verify loop runner install completeness in fresh projects.
+journeys:
+  - journey_meta:
+      id: J-LOOP-UNTIL-TERMINAL
+      persona: specflow_operator
+      owner_ticket: LOOP-RUNTIME-04
+      assertion_bar: ledger shows repeated gate attempts until a terminal stop
+    scenario: run all unblocked mechanical gates
+    given:
+      - a run_contract exists at GATE_B with valid local ticket evidence
+    when:
+      - the operator runs specflow run spec-build --until-terminal
+    then:
+      - Gate B verifiers execute
+      - the run advances to GATE_B5
+      - the next generative stop writes a prompt and stops
+  - journey_meta:
+      id: J-LOOP-YAML-SEQUENCE
+      persona: maintainer
+      owner_ticket: LOOP-RUNTIME-05
+      assertion_bar: sequence re-read from the YAML path in the contract
+    scenario: compile loop YAML into stage order
+    given:
+      - run_contract.path points at templates/QA/loops/spec-build.yaml
+    when:
+      - the runner calculates the next stage
+    then:
+      - stages are read from the YAML file
+      - fallback hardcoded order is used only if the YAML cannot be loaded
+  - journey_meta:
+      id: J-GEN-STAGE-PROMPT
+      persona: agent_operator
+      owner_ticket: GEN-ADAPTER-05
+      assertion_bar: prompt file re-reads current stage and human gates
+    scenario: materialize the next generative stage prompt
+    given:
+      - no verifier registry exists for the current stage
+    when:
+      - the runner stops with agent_action_required
+    then:
+      - .specflow/runs/<slug>/prompts/<stage>.md exists
+      - the prompt includes durable evidence and never_without_human
+  - journey_meta:
+      id: J-GEN-SESSION-RESUME
+      persona: interrupted_agent
+      owner_ticket: GEN-ADAPTER-06
+      assertion_bar: command argv contains the stored session id
+    scenario: resume a provider session
+    given:
+      - a provider output event includes a session id
+    when:
+      - the next adapter command is built with that id
+    then:
+      - Claude receives a resume flag
+      - Codex receives an exec resume invocation
+  - journey_meta:
+      id: J-GEN-LIVE-SMOKE
+      persona: local_user
+      owner_ticket: GEN-ADAPTER-07
+      assertion_bar: smoke command is dry-run unless --live is present
+    scenario: run a safe adapter smoke check
+    given:
+      - the user has an authenticated local provider CLI
+    when:
+      - specflow adapter-smoke claude-print --live is run
+    then:
+      - the provider receives a bounded one-line prompt
+      - forbidden human-gate actions still block
+  - journey_meta:
+      id: J-PROVENANCE-DIFF
+      persona: reviewer
+      owner_ticket: PROVENANCE-02
+      assertion_bar: suspicious diff lines fail the provenance gate
+    scenario: audit implementation diff for made-up values
+    given:
+      - a feature-build slice changed code or tests
+    when:
+      - specflow provenance evidence/file.json --git-diff runs
+    then:
+      - unallowed mock/fake/stub additions fail
+      - value-bearing literals without provenance fail
+  - journey_meta:
+      id: J-GATEC-STATUS
+      persona: release_operator
+      owner_ticket: GATE-C-01
+      assertion_bar: CLI reports green, red, or pending from PR checks
+    scenario: read Gate C status
+    given:
+      - a PR exists with GitHub check runs
+    when:
+      - specflow ci-status <pr-number> runs
+    then:
+      - failing checks are listed
+      - the gate_c field is red, pending, or green
+  - journey_meta:
+      id: J-LOOP-RUN-STATUS
+      persona: returning_agent
+      owner_ticket: LOOP-RUNTIME-06
+      assertion_bar: status output re-reads contract and ledger tail
+    scenario: inspect durable loop status
+    given:
+      - a run_contract and ledger exist
+    when:
+      - specflow run status --contract <path> runs
+    then:
+      - current stage and terminal status are printed
+      - recent ledger entries are included
+  - journey_meta:
+      id: J-INSTALL-LOOP-COMPLETE
+      persona: fresh_codespace_agent
+      owner_ticket: INSTALL-LOOP-01
+      assertion_bar: verify reports missing local loop assets as install failures
+    scenario: detect incomplete loop installation
+    given:
+      - a project is missing loop selector skills or adapter policies
+    when:
+      - specflow verify runs
+    then:
+      - missing skills fail install health
+      - missing adapter policy templates fail install health

--- a/docs/specs/genuine-looper/falsification.md
+++ b/docs/specs/genuine-looper/falsification.md
@@ -1,0 +1,66 @@
+# Falsification Pass - genuine-looper
+
+PRD SHA-256: d5d0b1540955a51a3b7c62b7bf1ecffcc9759ae2abc6f78f8e932789e9a522dc
+
+## Premise Attack
+| Premise | Source | Could be false because | Verdict | Required correction |
+|---|---|---|---|---|
+| Specflow needs bounded continuation to be a genuine looper | User request and loop YAML execution rules | Agents may still need HITL at generative stages | Holds with stipulation | Continue through mechanical gates only and stop honestly at generative work |
+| YAML should drive stage order | `templates/QA/loops/*.yaml` | The YAML might be incomplete for terminal handoff states | Holds | Use YAML first and fallback defaults when absent |
+| Diff provenance can catch made-up values | User concern about hard-coded data | Static scanning cannot prove semantic truth | Holds with stipulation | Treat it as a gate for obvious risks plus provenance evidence, not full proof |
+| CI status readback is enough for Gate C routing | `gh pr checks` behavior | GitHub auth or PR context may be missing | Holds | Fail closed with actionable auth/repo message |
+
+## Claim Inventory
+| Claim | Type | Source support | Load-bearing? | Status | What breaks downstream if wrong | Correction |
+|---|---|---|---|---|---|---|
+| `specflow run` currently exists and can be extended | impl-choice | `bin/specflow.js`, `scripts/specflow-runner.cjs` | Yes | Would require a new command surface | Reuse existing command |
+| Existing loop YAML has stage and rail IDs | definition | `templates/QA/loops/spec-build.yaml`, `templates/QA/loops/feature-build.yaml` | Yes | YAML-derived sequence would be impossible | Read `stages[].id` or `rails[].id` |
+| Adapter policy templates install under `.specflow/adapter-policies` | definition | `setup-project.sh`, `templates/adapter-policies/*.yml` | Yes | Verify check would point at nonexistent convention | Reuse installed path |
+| Provenance is a feature-build rail | definition | `templates/QA/loops/feature-build.yaml` | Yes | Diff gate would be in the wrong loop | Wire under `specflow provenance` |
+
+## Dependency Audit
+| Edge (A -> B) | Reason edge exists | False-edge risk | Verdict | Correction |
+|---|---|---|---|---|
+| YAML stage order -> bounded continuation | Runner needs next-stage calculation for every iteration | YAML and code drift | Holds | Tests assert YAML-derived sequence |
+| Stage prompt -> provider adapter | Generative stages need concrete instructions | Prompt could omit human gates | Holds | Prompt includes `never_without_human` |
+| Provider event parser -> session resume | Resume id must come from provider output | Providers may use different field names | Holds with stipulation | Parser accepts common session id spellings |
+| Diff audit -> provenance gate | Hard-coded values appear in changed lines | False positives are possible | Holds | Allow explicit contract-approved lines |
+
+## Acceptance Gate Attack
+| Gate | How it could be gamed | Missing oracle | Correction |
+|---|---|---|---|
+| `--until-terminal` | Loop exits after one pass and claims done | Iteration count and ledger tail | Contract test requires two iterations |
+| YAML state machine | Code still uses hardcoded order | Re-read loop YAML | Contract test reads `templates/QA/loops/spec-build.yaml` |
+| Stage prompt | Prompt written but missing constraints | Prompt content assertion | Contract test checks stage and human gates |
+| Provenance diff | JSON passes while code adds literals | Diff scan | Contract test rejects suspicious added line |
+| Install completeness | Fresh codespace misses policy files | Verify output | Installer test checks missing policy failure |
+
+## Source / Reality Ledger
+| Concrete claim | Verified against (file / query) | Holds? | Evidence |
+|---|---|---|---|
+| Feature-build has provenance rail | `templates/QA/loops/feature-build.yaml` | Yes | Rail `6_provenance` defines the audit |
+| Setup installs adapter policies | `setup-project.sh` | Yes | Copy block targets `.specflow/adapter-policies` |
+| Runner already has adapter event parsing | `scripts/specflow-runner.cjs` | Yes | `parseProviderEvents` exists |
+| Provenance gate already validates JSON evidence | `scripts/provenance-gate.cjs` | Yes | `auditProvenance` exists |
+
+## Overclaim / Scope Leakage
+| Text | Why it overclaims | Replacement text |
+|---|---|---|
+| Specflow fully automates agents | Live providers and human gates remain external | Specflow controls local contracted loop execution and stops honestly |
+| Provenance proves all truth | Static scan is not semantic proof | Provenance gate rejects obvious laundering and requires source evidence |
+| CI status command runs Gate C | It reads checks; it does not create protected CI | CI status command classifies existing Gate C checks |
+
+## Banned-Mode Self-Check
+| Banned mode | Present? | Evidence / note |
+|---|---|---|
+| blanket dependency | No | Dependencies name concrete files |
+| definition-as-assumption | No | "Looper" is decomposed into runtime behaviors |
+| source laundering | No | Repo claims have file sources |
+| nearby-proof | No | Tests assert behavior directly |
+| green-by-assertion | No | Gate commands are runnable |
+| inventory-as-reliance | No | Reuse is declared separately from proof |
+| unapplied correction | No | Stipulations are reflected in non-goals and ACs |
+
+## Final Verdict
+
+PASS WITH STIPULATIONS. Owner: feature-build implementer must keep provider output behind rerun gates and must not automate push, PR creation, merge, or `--no-verify`.

--- a/docs/specs/genuine-looper/hops.md
+++ b/docs/specs/genuine-looper/hops.md
@@ -1,0 +1,17 @@
+# Genuine Looper Hops
+
+| Journey | Surface | Entry | Required re-read assertion | Oracle |
+|---|---|---|---|---|
+| J-LOOP-UNTIL-TERMINAL | `runUntilTerminal` | `specflow run --until-terminal` | Ledger contains more than one entry when a mechanical gate advances into a generative stop. | `tests/contracts/loop-run-contract.test.js` |
+| J-LOOP-YAML-SEQUENCE | `loopSequence` | `run_contract.path` | Stage sequence matches `templates/QA/loops/spec-build.yaml`. | Contract test |
+| J-GEN-STAGE-PROMPT | `materializeStagePrompt` | generative stop | Prompt file contains current stage and `never_without_human`. | Contract test |
+| J-GEN-SESSION-RESUME | `buildAdapterCommand` | provider policy | Claude/Codex argv includes session resume value. | Contract test |
+| J-PROVENANCE-DIFF | `auditDiffText` | provenance CLI | Suspicious diff line fails. | Provenance gate test |
+| J-INSTALL-LOOP-COMPLETE | `verify-setup.sh` | fresh project verify | Missing adapter policies fail install health. | Installer test |
+
+## Seam-Derived Hops (Gate B)
+
+| Seam surface | Pair | Kind | Required re-read assertion |
+|---|---|---|---|
+| `ledger.jsonl` | LOOP-RUNTIME-04 -> LOOP-RUNTIME-06 | writer-reader | A run-until-terminal pass writes compact ledger entries that `specflow run status` re-reads in order. |
+| `nextStage` | LOOP-RUNTIME-05 -> LOOP-RUNTIME-04 | writer-reader | YAML-derived next-stage calculation is the value consumed by bounded continuation before every iteration. |

--- a/docs/specs/genuine-looper/issues.json
+++ b/docs/specs/genuine-looper/issues.json
@@ -1,0 +1,7 @@
+[
+  {
+    "number": 82,
+    "title": "[SPECFLOW] Genuine looper runtime completion",
+    "body": "Journey IDs: J-LOOP-UNTIL-TERMINAL, J-LOOP-YAML-SEQUENCE, J-GEN-STAGE-PROMPT, J-GEN-SESSION-RESUME, J-GEN-LIVE-SMOKE, J-PROVENANCE-DIFF, J-GATEC-STATUS, J-LOOP-RUN-STATUS, J-INSTALL-LOOP-COMPLETE\n\nSee docs/specs/genuine-looper/tickets.md for the local ticket packet."
+  }
+]

--- a/docs/specs/genuine-looper/prd.md
+++ b/docs/specs/genuine-looper/prd.md
@@ -1,0 +1,34 @@
+# Genuine Looper Completion PRD
+
+**Date:** 2026-06-30
+**Loop:** spec-build
+**Goal:** Make `specflow run` behave like a bounded contracted loop runner instead of a reference-doc launcher.
+
+## Problem
+
+Specflow now installs loop YAML, skills, adapter policies, and a local run contract, but an agent can still stop after one stage, cherry-pick instructions, or treat the YAML as background reading. A genuine looper needs executable stage state, bounded continuation, materialized stage prompts for generative work, provider resume evidence, provenance checks over changed code, install health checks, and CI/Gate C readback.
+
+## Requirements
+
+- `LOOP-RUNTIME-04`: `specflow run --until-terminal` continues through all unblocked mechanical gates until handoff, a human gate, missing evidence, adapter failure, or iteration budget exhaustion.
+- `LOOP-RUNTIME-05`: the runner compiles `templates/QA/loops/*.yaml` into the executable stage/rail sequence instead of relying only on hardcoded maps.
+- `GEN-ADAPTER-05`: every generative stop writes a stage prompt that includes goal, current stage, next gate, durable evidence, and `never_without_human`.
+- `GEN-ADAPTER-06`: provider session IDs from Claude/Codex output are persisted and can be supplied back into the next provider command.
+- `GEN-ADAPTER-07`: `specflow adapter-smoke <provider> --live` remains opt-in and uses a bounded one-line smoke prompt.
+- `PROVENANCE-02`: `specflow provenance` can audit a diff for value-bearing literals, mock/fake/stub paths, and missing source traces after implementation.
+- `GATE-C-01`: Specflow exposes a command to read PR check status and classify Gate C as green, red, or pending.
+- `LOOP-RUNTIME-06`: `specflow run status --contract <path>` reports current stage, terminal status, sequence, and ledger tail.
+- `INSTALL-LOOP-01`: `specflow verify` fails install health when loop skills or safe adapter policy templates are missing in a fresh project.
+
+## Non-Goals
+
+- Hosted scheduling, background daemons, or automatic PR push/merge.
+- Automatically trusting provider output as a gate result.
+- Running live Claude/Codex smoke checks unless explicitly requested with `--live`.
+
+## Success Criteria
+
+- Contract tests prove YAML-derived stage order, bounded continuation, stage prompt materialization, session resume command construction, status reporting, and adapter smoke prompting.
+- Provenance tests reject suspicious diff literals and unallowed mock/fake/stub additions.
+- Installer tests catch missing loop selector skills and missing adapter policy templates.
+- Feature-build evidence proves the changed files are source-proven and the implemented gates passed locally.

--- a/docs/specs/genuine-looper/run-contract.yaml
+++ b/docs/specs/genuine-looper/run-contract.yaml
@@ -1,0 +1,22 @@
+run_contract:
+  loop: feature-build
+  goal: Implement the genuine-looper runtime completion ticket packet.
+  input_artifact: docs/specs/genuine-looper/prd.md
+  path: templates/QA/loops/feature-build.yaml
+  current_stage_or_rail: 7_ci_handoff
+  next_gate: human push/PR or CI readback
+  durable_evidence:
+    - docs/specs/genuine-looper/prd.md
+    - docs/specs/genuine-looper/contract.yml
+    - docs/specs/genuine-looper/tickets.md
+    - docs/specs/genuine-looper/specflow-audit.md
+    - docs/specs/genuine-looper/simulation.md
+    - evidence/provenance-genuine-looper.json
+  stop_condition: Stop before push/PR/merge; human authorization is required for those actions.
+  never_without_human:
+    - git push
+    - open PR
+    - merge
+    - --no-verify
+    - override contract
+  terminal_status: ci_handoff

--- a/docs/specs/genuine-looper/simulation.md
+++ b/docs/specs/genuine-looper/simulation.md
@@ -1,0 +1,17 @@
+# Genuine Looper - Gate B.5 Simulation
+
+**Date:** 2026-06-30
+**Stage:** GATE_B5
+**Status:** PASS
+
+## Personas
+
+- **Specflow operator:** starts at Gate B and expects the runner to continue to the next true blocker. The `--until-terminal` journey covers this and records the ledger.
+- **Fresh codespace agent:** has no global skill list entry and needs local install assets. The installer/verify journey covers loop selector skills and adapter policies.
+- **Interrupted adapter user:** provider returns a session id and the next run must resume instead of starting over. The session-resume journey covers this.
+- **Reviewer:** suspects made-up values in code. The provenance diff journey covers suspicious literals and mock/fake/stub paths.
+- **Release operator:** needs Gate C status. The CI status journey covers `gh pr checks` readback and failure routing.
+
+## Gate Result
+
+No CRITICAL design gap survives. The implementation must still stop before push/PR/merge unless a human explicitly authorizes those actions.

--- a/docs/specs/genuine-looper/specflow-audit.md
+++ b/docs/specs/genuine-looper/specflow-audit.md
@@ -1,0 +1,18 @@
+# Genuine Looper - Gate B Audit
+
+**Date:** 2026-06-30
+**Stage:** GATE_B
+**Status:** PASS after local verifier execution.
+
+## Required Checks
+
+| Check | Command | Result |
+|---|---|---|
+| Falsification | `node scripts/verify-falsification.cjs docs/specs/genuine-looper/falsification.md --require-pass --binds-prd docs/specs/genuine-looper/prd.md` | PASS |
+| Seam-lite | `node scripts/verify-seams.cjs docs/specs/genuine-looper/tickets.json --repo-root .` | PASS |
+| ADR/reuse | `node scripts/verify-adr.cjs docs/specs/genuine-looper/tickets.json --repo-root .` | PASS |
+| Ticket-journey join | `node scripts/verify-ticket-journey.cjs docs/specs/genuine-looper --issues docs/specs/genuine-looper/issues.json` | PASS |
+
+## Handoff
+
+Spec-build gates are green and B.5 simulation is persisted. Feature-build may implement the local ticket packet for #82.

--- a/docs/specs/genuine-looper/tickets.json
+++ b/docs/specs/genuine-looper/tickets.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "LOOP-RUNTIME-04",
+    "title": "Add bounded run-until-terminal execution",
+    "writes": ["runUntilTerminal", "specflow run", "ledger.jsonl"],
+    "reads": ["executeVerifierRegistry", "nextStage", "run_contract"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing runner and loop templates.",
+    "reuses": ["scripts/specflow-runner.cjs", "templates/QA/loops/spec-build.yaml", "templates/QA/loops/feature-build.yaml"],
+    "journeys": ["J-LOOP-UNTIL-TERMINAL"]
+  },
+  {
+    "id": "LOOP-RUNTIME-05",
+    "title": "Compile loop YAML into executable state machine",
+    "writes": ["loopSequence", "nextStage"],
+    "reads": ["templates/QA/loops/spec-build.yaml", "templates/QA/loops/feature-build.yaml", "contract.path"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing loop YAML and runner.",
+    "reuses": ["scripts/specflow-runner.cjs", "js-yaml"],
+    "journeys": ["J-LOOP-YAML-SEQUENCE"]
+  },
+  {
+    "id": "GEN-ADAPTER-05",
+    "title": "Materialize generative stage prompts",
+    "writes": ["materializeStagePrompt", ".specflow/runs", "prompts"],
+    "reads": ["run_contract", "never_without_human", "templates/QA/loops"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing adapter and loop-runner surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "templates/adapter-policies/claude-print.safe.yml"],
+    "journeys": ["J-GEN-STAGE-PROMPT"]
+  },
+  {
+    "id": "GEN-ADAPTER-06",
+    "title": "Persist and resume provider session ids",
+    "writes": ["provider_session_id", "buildAdapterCommand"],
+    "reads": ["parseProviderEvents", "session_id"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing provider event parser.",
+    "reuses": ["scripts/specflow-runner.cjs"],
+    "journeys": ["J-GEN-SESSION-RESUME"]
+  },
+  {
+    "id": "GEN-ADAPTER-07",
+    "title": "Add opt-in live Claude/Codex smoke checks",
+    "writes": ["adapter-smoke", "planAdapterSmoke"],
+    "reads": ["runAdapter", "never_without_human"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing adapter policy support.",
+    "reuses": ["bin/specflow.js", "scripts/specflow-runner.cjs"],
+    "journeys": ["J-GEN-LIVE-SMOKE"]
+  },
+  {
+    "id": "PROVENANCE-02",
+    "title": "Audit git diff for provenance risks",
+    "writes": ["auditDiffText", "specflow provenance"],
+    "reads": ["source_provenance", "git diff"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against the existing provenance gate.",
+    "reuses": ["scripts/provenance-gate.cjs", "bin/specflow.js"],
+    "journeys": ["J-PROVENANCE-DIFF"]
+  },
+  {
+    "id": "GATE-C-01",
+    "title": "Read PR CI status for Gate C triage",
+    "writes": ["ci-status"],
+    "reads": ["gh pr checks"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing gh-based audit command style.",
+    "reuses": ["bin/specflow.js"],
+    "journeys": ["J-GATEC-STATUS"]
+  },
+  {
+    "id": "LOOP-RUNTIME-06",
+    "title": "Add specflow run status",
+    "writes": ["runStatus", "specflow run status"],
+    "reads": ["run_contract", "ledger.jsonl"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing run contract storage.",
+    "reuses": ["scripts/specflow-runner.cjs", "bin/specflow.js"],
+    "journeys": ["J-LOOP-RUN-STATUS"]
+  },
+  {
+    "id": "INSTALL-LOOP-01",
+    "title": "Verify loop runner install completeness",
+    "writes": ["verify-setup.sh"],
+    "reads": ["specflow-loop-selector", ".specflow/adapter-policies"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing installer and verify tests.",
+    "reuses": ["setup-project.sh", "verify-setup.sh", "tests/hooks/installer-fixes.test.js"],
+    "journeys": ["J-INSTALL-LOOP-COMPLETE"]
+  }
+]

--- a/docs/specs/genuine-looper/tickets.md
+++ b/docs/specs/genuine-looper/tickets.md
@@ -1,0 +1,30 @@
+# Genuine Looper Ticket Packet
+
+## #82 - [SPECFLOW] Genuine looper runtime completion
+
+Implement the remaining contracted-loop runtime surfaces:
+
+- `LOOP-RUNTIME-04`: bounded `--until-terminal` execution.
+- `LOOP-RUNTIME-05`: YAML-derived stage sequence.
+- `GEN-ADAPTER-05`: stage prompt materialization.
+- `GEN-ADAPTER-06`: provider session persistence/resume.
+- `GEN-ADAPTER-07`: opt-in live adapter smoke.
+- `PROVENANCE-02`: diff provenance gate.
+- `GATE-C-01`: PR CI status readback.
+- `LOOP-RUNTIME-06`: `specflow run status`.
+- `INSTALL-LOOP-01`: install completeness verification.
+
+**Journey contract:** `docs/specs/genuine-looper/contract.yml`
+**Journey IDs:** J-LOOP-UNTIL-TERMINAL, J-LOOP-YAML-SEQUENCE, J-GEN-STAGE-PROMPT, J-GEN-SESSION-RESUME, J-GEN-LIVE-SMOKE, J-PROVENANCE-DIFF, J-GATEC-STATUS, J-LOOP-RUN-STATUS, J-INSTALL-LOOP-COMPLETE
+
+## Acceptance Criteria
+
+- Given a run contract at a mechanical gate, when `specflow run --until-terminal` runs, then it repeats unblocked verifier stages until the next terminal stop and records every attempt in the ledger.
+- Given a loop YAML path in the contract, when the runner determines stage order, then it uses `stages[].id` or `rails[].id` from that YAML and falls back only if the YAML cannot be loaded.
+- Given a generative stage, when no verifier registry applies, then a stage prompt file is written with goal, current stage, next gate, durable evidence, and human gates.
+- Given provider JSON/JSONL includes a session id, when the next command is built, then Claude/Codex resume arguments include that id.
+- Given `specflow adapter-smoke <provider>` runs without `--live`, then it remains a dry-run; with `--live`, it sends only the bounded smoke prompt.
+- Given `specflow provenance` is run with `--diff`, `--git-diff`, or `--staged-diff`, then unallowed mock/fake/stub additions and suspicious value-bearing literals fail.
+- Given a PR number, when `specflow ci-status <pr>` runs, then Gate C is reported as green, red, or pending from `gh pr checks`.
+- Given a run contract path, when `specflow run status --contract <path>` runs, then current stage, terminal status, sequence, and ledger tail are printed.
+- Given a fresh project is missing local loop selector skills or adapter policy templates, when `specflow verify` runs, then install health fails with actionable paths.

--- a/docs/specs/genuine-looper/verdict.md
+++ b/docs/specs/genuine-looper/verdict.md
@@ -1,0 +1,17 @@
+# Genuine Looper - Gate A Verdict
+
+**Date:** 2026-06-30
+**Loop:** spec-build
+**Stage:** GATE_A
+**Verdict:** SHIP_WITH_STIPULATIONS
+
+## Why This Ships
+
+The PRD closes the non-marginal loop gaps that remained after the first runtime pass: bounded continuation, YAML-driven stage order, provider prompts/resume state, diff provenance, CI readback, status reporting, and install completeness. These are concrete runtime and verifier behaviors, not positioning copy.
+
+## Stipulations
+
+- Provider output never advances a gate by itself; the owning verifier must rerun.
+- Live provider smoke checks remain opt-in.
+- `never_without_human` actions remain hard stops.
+- Hosted scheduling remains out of scope.

--- a/docs/specs/loop-completion/prd.md
+++ b/docs/specs/loop-completion/prd.md
@@ -1,0 +1,70 @@
+# Loop Completion PRD
+
+GitHub issue: #81
+
+## Job To Be Done
+
+When an operator runs Specflow as a loop, the runner must do more than write a
+contract. It must execute mapped mechanical gates, reject stale ticket inputs,
+capture provider evidence, enforce human gates from structured events, install
+safe adapter policies, and expose provenance as a reusable command.
+
+## Scope
+
+In scope:
+
+- Stage executor and verifier registry for `specflow run`.
+- Simulation freshness checks before feature-build readiness.
+- Opt-in live adapter smoke checks for Claude and Codex CLIs.
+- Structured Claude/Codex event parsing for final text, session IDs, errors,
+  and tool/action events.
+- Stronger `never_without_human` enforcement from parsed events and denied
+  command patterns.
+- Safe adapter policy templates installed by `specflow init`.
+- Reusable `specflow provenance` gate.
+
+Not in scope:
+
+- Hosted scheduling.
+- Automatic push/PR/merge.
+- Live provider calls in CI by default.
+
+## Requirements
+
+- REQ-01 (MUST): `specflow run` must map current loop stage/rail to a verifier
+  command when one exists and execute it before advancing.
+- REQ-02 (MUST): Feature-build readiness must fail when simulation evidence is
+  missing or older than the ticket/spec input.
+- REQ-03 (MUST): Live Claude/Codex adapter smoke checks must be opt-in and
+  skipped by default in CI.
+- REQ-04 (MUST): Provider JSON/JSONL streams must be parsed into final response,
+  session ID, errors, and tool/action events where available.
+- REQ-05 (MUST): `never_without_human` must be enforced from parsed provider
+  events and denied command patterns, not only raw text.
+- REQ-06 (MUST): `specflow init` must scaffold safe adapter policy templates.
+- REQ-07 (MUST): Add reusable `specflow provenance <file>` command that rejects
+  missing source provenance and mock/literal laundering.
+
+## Acceptance Criteria
+
+- AC-1: A run contract at `GATE_B` with ticket artifacts executes seam, ADR, and
+  ticket-journey verifiers and advances only on success.
+- AC-2: A feature-build contract with stale simulation evidence stops before
+  implementation with an actionable error.
+- AC-3: `specflow adapter-smoke claude-print --dry-run` and
+  `specflow adapter-smoke codex-exec --dry-run` print planned checks without
+  invoking live models.
+- AC-4: Provider event parsers extract final text and detect tool calls that
+  attempt forbidden actions.
+- AC-5: `specflow init` installs starter policy templates under
+  `.specflow/adapter-policies/`.
+- AC-6: `specflow provenance evidence/provenance-77-78-80.json` passes, while a
+  provenance file with no source trace fails.
+
+## Success Metrics
+
+- The runner can advance at least one real mechanical gate without manual
+  command copy/paste.
+- Feature-build can block stale simulations before code changes.
+- Adapter tests remain deterministic and do not call live models unless the
+  operator opts in.

--- a/docs/specs/loop-completion/run-contract.yaml
+++ b/docs/specs/loop-completion/run-contract.yaml
@@ -1,0 +1,19 @@
+run_contract:
+  loop: feature-build
+  goal: complete loop runtime missing requirements from stage execution through provenance
+  input_artifact: issue #81 + docs/specs/loop-completion/prd.md
+  path: templates/QA/loops/feature-build.yaml
+  current_stage_or_rail: 7_ci_handoff
+  next_gate: human push triggers branch-protected CI / Gate C
+  durable_evidence:
+    - docs/specs/loop-completion/prd.md
+    - evidence/provenance-loop-completion.json
+  simulation_required: false
+  stop_condition: Stop at human CI handoff after local tests and provenance pass.
+  never_without_human:
+    - git push
+    - open PR
+    - merge
+    - --no-verify
+    - override contract
+  terminal_status: ready_for_handoff

--- a/evidence/provenance-genuine-looper.json
+++ b/evidence/provenance-genuine-looper.json
@@ -1,0 +1,41 @@
+{
+  "feature": "genuine-looper",
+  "result": "pass",
+  "source_provenance": [
+    {
+      "claim": "Loop stage order is derived from loop YAML when available.",
+      "source": "scripts/specflow-runner.cjs loadLoopDefinition, loopSequenceFromDefinition, loopSequence",
+      "verification": "tests/contracts/loop-run-contract.test.js loads templates/QA/loops/spec-build.yaml and asserts stage ids."
+    },
+    {
+      "claim": "Bounded run-until-terminal stops at a real terminal condition and records ledger evidence.",
+      "source": "scripts/specflow-runner.cjs runUntilTerminal and runLoop",
+      "verification": "tests/contracts/loop-run-contract.test.js asserts a Gate B pass followed by a GATE_B5 agent_action_required prompt."
+    },
+    {
+      "claim": "Generative stages produce durable prompt files with human-gate constraints.",
+      "source": "scripts/specflow-runner.cjs materializeStagePrompt",
+      "verification": "tests/contracts/loop-run-contract.test.js re-reads the generated prompt and checks current stage plus never_without_human."
+    },
+    {
+      "claim": "Provider session ids are parsed and resume arguments are generated for Claude and Codex.",
+      "source": "scripts/specflow-runner.cjs parseProviderEvents and buildAdapterCommand",
+      "verification": "tests/contracts/loop-run-contract.test.js checks Claude --resume and Codex exec resume argv."
+    },
+    {
+      "claim": "Diff provenance rejects suspicious value-bearing literals and unallowed test-double paths.",
+      "source": "scripts/provenance-gate.cjs auditDiffText",
+      "verification": "tests/contracts/provenance-gate.test.js rejects a region_code literal and permits only explicitly contract-allowed opt-in smoke wording."
+    },
+    {
+      "claim": "Fresh install verification fails when adapter policy templates are missing.",
+      "source": "verify-setup.sh adapter policy checks",
+      "verification": "tests/hooks/installer-fixes.test.js expects missing .specflow/adapter-policies/claude-print.safe.yml to fail install health."
+    },
+    {
+      "claim": "Gate C status is exposed as a CLI readback command.",
+      "source": "bin/specflow.js ci-status command",
+      "verification": "Manual CLI surface review plus package command help; live gh readback remains environment-dependent."
+    }
+  ]
+}

--- a/evidence/provenance-loop-completion.json
+++ b/evidence/provenance-loop-completion.json
@@ -1,0 +1,40 @@
+{
+  "issues": ["loop-completion"],
+  "feature_build": "stage executor, freshness, provider parsing, policy templates, provenance gate",
+  "source_provenance": [
+    {
+      "claim": "specflow run can execute mapped mechanical gates",
+      "source": "scripts/specflow-runner.cjs executeVerifierRegistry/verifierCommandsForStage",
+      "verification": "tests/contracts/loop-run-contract.test.js creates temporary Gate B artifacts and runs the real verify-seams, verify-adr, and verify-ticket-journey scripts"
+    },
+    {
+      "claim": "feature-build can reject stale simulation evidence",
+      "source": "scripts/specflow-runner.cjs isSimulationFresh",
+      "verification": "tests/contracts/loop-run-contract.test.js checks newer ticket input fails against older simulation"
+    },
+    {
+      "claim": "provider event streams are parsed for final text and tool events",
+      "source": "scripts/specflow-runner.cjs parseProviderEvents/forbiddenFromProviderEvents",
+      "verification": "tests/contracts/loop-run-contract.test.js parses JSONL with a tool_call attempting git push"
+    },
+    {
+      "claim": "adapter policy templates are installed by init",
+      "source": "setup-project.sh and templates/adapter-policies/*.safe.yml",
+      "verification": "setup-project.sh copies templates into .specflow/adapter-policies"
+    },
+    {
+      "claim": "provenance is a reusable gate",
+      "source": "scripts/provenance-gate.cjs and bin/specflow.js provenance command",
+      "verification": "tests/contracts/provenance-gate.test.js and specflow provenance evidence/provenance-loop-completion.json"
+    }
+  ],
+  "checks": [
+    "npx jest tests/contracts/loop-run-contract.test.js tests/contracts/provenance-gate.test.js --no-coverage --runInBand",
+    "node bin/specflow.js provenance evidence/provenance-loop-completion.json",
+    "node bin/specflow.js adapter-smoke claude-print --dry-run",
+    "node bin/specflow.js adapter-smoke codex-exec --dry-run",
+    "npm test -- --runInBand"
+  ],
+  "result": "pass",
+  "notes": "Live Claude/Codex provider calls remain opt-in. CI uses local fake/structural checks by default."
+}

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -251,6 +251,18 @@ if [ "$REFRESHED_KIT" = false ]; then
   echo -e "${YELLOW}⚠️${NC}  QA kit/scripts not in source (curl install?) — run 'specflow init' from the package to install them"
 fi
 
+ADAPTER_POLICY_DIR="$SCRIPT_DIR/templates/adapter-policies"
+if [ -d "$ADAPTER_POLICY_DIR" ]; then
+  mkdir -p "$TARGET_DIR/.specflow/adapter-policies"
+  for policy in "$ADAPTER_POLICY_DIR"/*.yml; do
+    [ -f "$policy" ] || continue
+    cp "$policy" "$TARGET_DIR/.specflow/adapter-policies/"
+    echo -e "${GREEN}✓${NC} Installed .specflow/adapter-policies/$(basename "$policy")"
+  done
+else
+  echo -e "${YELLOW}⚠️${NC}  Adapter policy templates not found in Specflow source"
+fi
+
 echo ""
 
 # ============================================================================
@@ -336,6 +348,13 @@ done
 if [ ! -f "$TARGET_DIR/AGENTS.md" ] || ! grep -q "Specflow Loop Routing" "$TARGET_DIR/AGENTS.md" 2>/dev/null; then
   INSTALL_OK=false
 fi
+for policy_path in \
+  ".specflow/adapter-policies/claude-print.safe.yml" \
+  ".specflow/adapter-policies/codex-exec.safe.yml"; do
+  if [ ! -f "$TARGET_DIR/$policy_path" ]; then
+    INSTALL_OK=false
+  fi
+done
 
 if [ "$INSTALL_OK" = true ]; then
   echo -e "${BLUE}╔═══════════════════════════════════════════════════════════╗${NC}"
@@ -359,6 +378,7 @@ echo "  .claude/hooks/README.md            - Documentation"
 echo "  .claude/skills/specflow-loop-selector - Claude Code loop router"
 echo "  .codex/skills/specflow-loop-selector  - Codex loop router"
 echo "  .agents/skills/specflow-loop-selector - Generic agent loop router"
+echo "  .specflow/adapter-policies/          - Safe Claude/Codex adapter policies"
 echo "  AGENTS.md                         - Agent bootstrap instructions"
 echo ""
 if [ ! -f "$TARGET_DIR/.codex/skills/specflow-loop-selector/SKILL.md" ]; then

--- a/scripts/provenance-gate.cjs
+++ b/scripts/provenance-gate.cjs
@@ -8,6 +8,7 @@
  */
 
 const { readFileSync, existsSync } = require('fs');
+const { spawnSync } = require('child_process');
 
 function loadJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -31,10 +32,44 @@ function auditProvenance(doc) {
   return { ok: violations.length === 0, violations };
 }
 
+function auditDiffText(diffText, options = {}) {
+  const violations = [];
+  const allowPattern = /specflow-provenance-allow|contract-allowed|fake provider|fixture default|opt-in smoke/i;
+  const suspiciousLiteral = /(region_code|price|amount|total|rate|email|phone|postal|zipcode|zip|address|apiKey|token)\s*[:=]\s*['"`][^'"`]+['"`]/i;
+  let currentFile = null;
+  String(diffText || '').split(/\r?\n/).forEach((line, index) => {
+    const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
+    if (fileMatch) {
+      currentFile = fileMatch[1];
+      return;
+    }
+    if (!line.startsWith('+') || line.startsWith('+++')) return;
+    if (currentFile && /(^docs\/|^evidence\/|\.md$|\.mdx$)/i.test(currentFile)) return;
+    if (allowPattern.test(line)) return;
+    if (/\b(mock|fake|stub)\b/i.test(line)) { // specflow-provenance-allow: scanner owns banned term matching
+      violations.push(`diff line ${index + 1} adds mock/fake/stub path without explicit allowance`); // specflow-provenance-allow: scanner diagnostic
+    }
+    if (suspiciousLiteral.test(line) && !/source_provenance|provenance|test|fixture/i.test(line)) {
+      violations.push(`diff line ${index + 1} adds a value-bearing literal without source provenance`);
+    }
+  });
+  if (options.requireDiff && !String(diffText || '').trim()) violations.push('diff audit requested but diff is empty');
+  return { ok: violations.length === 0, violations };
+}
+
+function gitDiffText({ staged = false } = {}) {
+  const args = staged
+    ? ['diff', '--cached', '--', '.', ':(exclude)**/node_modules/**']
+    : ['diff', '--', '.', ':(exclude)**/node_modules/**'];
+  const result = spawnSync('git', args, { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
+  if (result.status !== 0) throw new Error(result.stderr || 'git diff failed');
+  return result.stdout || '';
+}
+
 function main(argv = process.argv.slice(2)) {
   const path = argv[0];
   if (!path) {
-    console.error('Usage: node scripts/provenance-gate.cjs <provenance.json>');
+    console.error('Usage: node scripts/provenance-gate.cjs <provenance.json> [--diff <file>|--git-diff|--staged-diff]');
     return 2;
   }
   if (!existsSync(path)) {
@@ -48,6 +83,24 @@ function main(argv = process.argv.slice(2)) {
     console.error(`✗ could not parse provenance: ${e.message}`);
     return 2;
   }
+  const diffFlag = argv.findIndex((arg) => arg === '--diff');
+  if (diffFlag !== -1) {
+    const diffPath = argv[diffFlag + 1];
+    if (!diffPath || !existsSync(diffPath)) {
+      console.error(`✗ no such diff file: ${diffPath || '<missing>'}`);
+      return 2;
+    }
+    const diffResult = auditDiffText(readFileSync(diffPath, 'utf8'), { requireDiff: true });
+    result = { ok: result.ok && diffResult.ok, violations: [...result.violations, ...diffResult.violations] };
+  }
+  if (argv.includes('--git-diff') || argv.includes('--staged-diff')) {
+    try {
+      const diffResult = auditDiffText(gitDiffText({ staged: argv.includes('--staged-diff') }), { requireDiff: false });
+      result = { ok: result.ok && diffResult.ok, violations: [...result.violations, ...diffResult.violations] };
+    } catch (e) {
+      result = { ok: false, violations: [...result.violations, e.message] };
+    }
+  }
   if (result.ok) {
     console.error('✓ provenance gate passed');
     return 0;
@@ -57,6 +110,6 @@ function main(argv = process.argv.slice(2)) {
   return 1;
 }
 
-module.exports = { auditProvenance };
+module.exports = { auditProvenance, auditDiffText, gitDiffText };
 
 if (require.main === module) process.exit(main());

--- a/scripts/provenance-gate.cjs
+++ b/scripts/provenance-gate.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * provenance-gate.cjs — reusable source-provenance gate for feature-build.
+ *
+ * The gate rejects empty "trust me" evidence and obvious mock/literal laundering
+ * in provenance notes. It is intentionally structural: feature-specific truth is
+ * carried by source_provenance rows that name source and verification.
+ */
+
+const { readFileSync, existsSync } = require('fs');
+
+function loadJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function auditProvenance(doc) {
+  const violations = [];
+  const rows = doc && Array.isArray(doc.source_provenance) ? doc.source_provenance : [];
+  if (!rows.length) violations.push('source_provenance must contain at least one row');
+  rows.forEach((row, index) => {
+    const prefix = `source_provenance[${index}]`;
+    if (!row.claim) violations.push(`${prefix}.claim is required`);
+    if (!row.source) violations.push(`${prefix}.source is required`);
+    if (!row.verification) violations.push(`${prefix}.verification is required`);
+    const text = `${row.claim || ''} ${row.source || ''} ${row.verification || ''}`;
+    if (/\b(mock|fake|stub|fixture)\b/i.test(text) && !/fake provider|fixture.*default|contract-allowed|opt-in/i.test(text)) {
+      violations.push(`${prefix} appears to rely on mock/fake/stub evidence without an explicit allowance`);
+    }
+  });
+  if (doc.result && !/^pass|passed$/i.test(doc.result)) violations.push(`result is not pass: ${doc.result}`);
+  return { ok: violations.length === 0, violations };
+}
+
+function main(argv = process.argv.slice(2)) {
+  const path = argv[0];
+  if (!path) {
+    console.error('Usage: node scripts/provenance-gate.cjs <provenance.json>');
+    return 2;
+  }
+  if (!existsSync(path)) {
+    console.error(`✗ no such provenance file: ${path}`);
+    return 2;
+  }
+  let result;
+  try {
+    result = auditProvenance(loadJson(path));
+  } catch (e) {
+    console.error(`✗ could not parse provenance: ${e.message}`);
+    return 2;
+  }
+  if (result.ok) {
+    console.error('✓ provenance gate passed');
+    return 0;
+  }
+  console.error('✗ provenance gate failed:');
+  result.violations.forEach((v) => console.error(`  - ${v}`));
+  return 1;
+}
+
+module.exports = { auditProvenance };
+
+if (require.main === module) process.exit(main());

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -169,7 +169,24 @@ function isSimulationFresh({ simulationPath, inputPaths = [] }) {
   return { ok: true, reason: null };
 }
 
-function loopSequence(contract) {
+function loadLoopDefinition(contractOrLoop, options = {}) {
+  const loop = typeof contractOrLoop === 'string' ? contractOrLoop : contractOrLoop.loop;
+  const definitionPath = (typeof contractOrLoop === 'object' && contractOrLoop.path) || LOOP_PATHS[loop];
+  if (!definitionPath) return null;
+  const root = options.root || process.cwd();
+  const absolute = resolve(root, definitionPath);
+  if (!existsSync(absolute)) return null;
+  return loadDataFile(absolute);
+}
+
+function loopSequenceFromDefinition(definition) {
+  if (!definition || typeof definition !== 'object') return [];
+  const collection = Array.isArray(definition.stages) ? definition.stages : definition.rails;
+  if (!Array.isArray(collection)) return [];
+  return collection.map((item) => item && item.id).filter(Boolean);
+}
+
+function fallbackLoopSequence(contract) {
   if (contract.loop === 'feature-build') {
     return ['1_ticket', '2_contract', '3_e2e', '4_oracle', '5_impl', '6_provenance', '7_ci_handoff'];
   }
@@ -179,8 +196,13 @@ function loopSequence(contract) {
   return [];
 }
 
-function nextStage(contract) {
-  const sequence = loopSequence(contract);
+function loopSequence(contract, options = {}) {
+  const fromDefinition = loopSequenceFromDefinition(loadLoopDefinition(contract, options));
+  return fromDefinition.length ? fromDefinition : fallbackLoopSequence(contract);
+}
+
+function nextStage(contract, options = {}) {
+  const sequence = loopSequence(contract, options);
   const index = sequence.indexOf(contract.current_stage_or_rail);
   if (index === -1 || index === sequence.length - 1) return contract.current_stage_or_rail;
   return sequence[index + 1];
@@ -260,6 +282,51 @@ function executeVerifierRegistry(contract, options = {}) {
   return { status: 'gate_passed', entries, advance: true };
 }
 
+function materializeStagePrompt(contract, options = {}) {
+  const stage = contract.current_stage_or_rail || 'stage';
+  const safeStage = String(stage).replace(/[^a-z0-9._-]+/gi, '-');
+  const baseDir = options.promptDir
+    || join(dirname(options.contractPath || contract.storage?.contract_path || defaultRunPaths(options.slug || 'specflow-run').contractPath), 'prompts');
+  const promptPath = options.promptPath || join(baseDir, `${safeStage}.md`);
+  const definition = loadLoopDefinition(contract, options);
+  const sequence = loopSequence(contract, options);
+  const next = nextStage(contract, options);
+  const stageSpec = [
+    ...(Array.isArray(definition?.stages) ? definition.stages : []),
+    ...(Array.isArray(definition?.rails) ? definition.rails : []),
+  ].find((item) => item && item.id === stage);
+  const content = [
+    `# Specflow ${contract.loop} Stage Prompt`,
+    '',
+    `Goal: ${contract.goal}`,
+    `Input artifact: ${contract.input_artifact}`,
+    `Current stage: ${stage}`,
+    `Next stage: ${next}`,
+    `Next gate: ${contract.next_gate}`,
+    '',
+    '## Contract Rules',
+    `- Loop path: ${contract.path}`,
+    `- Stop condition: ${contract.stop_condition}`,
+    `- Never without human: ${(contract.never_without_human || []).join(', ') || 'none declared'}`,
+    `- Durable evidence: ${(contract.durable_evidence || []).join(', ') || 'none declared'}`,
+    '',
+    '## Stage Definition',
+    stageSpec ? yaml.dump(stageSpec, { lineWidth: 120, noRefs: true }).trim() : 'No YAML stage body found; use the run contract and next gate.',
+    '',
+    '## Required Behavior',
+    '- Execute only this stage or rail.',
+    '- Persist durable evidence before claiming progress.',
+    '- Do not mark the gate passed yourself; rerun the owning Specflow verifier after work.',
+    '- Stop immediately if a never_without_human action would be required.',
+    '',
+    `Sequence: ${sequence.join(' -> ')}`,
+    '',
+  ].join('\n');
+  ensureDir(promptPath);
+  writeFileSync(promptPath, content, 'utf8');
+  return { promptPath, content };
+}
+
 function resolveTemplate(value, context) {
   return String(value).replace(/<slug>/g, context.slug || 'run').replace(/\$\{slug\}/g, context.slug || 'run');
 }
@@ -277,6 +344,8 @@ function normalizeAdapterPolicy(raw, context = {}) {
     args: policy.args || [],
     allowed_tools: policy.allowed_tools || [],
     denied_tools: policy.denied_tools || [],
+    prompt: policy.prompt || null,
+    session_id: policy.session_id || null,
     dry_run: Boolean(policy.dry_run),
     transcript_path: resolveTemplate(policy.transcript_path, context),
     output_path: resolveTemplate(policy.output_path, context),
@@ -299,17 +368,24 @@ function buildAdapterCommand(policy, promptPath) {
     if (deniedTools.length && !args.includes('--disallowedTools') && !args.includes('--disallowed-tools')) {
       args.push('--disallowedTools', deniedTools.join(','));
     }
+    if (policy.session_id && !args.includes('--resume') && !args.includes('--session-id')) {
+      args.push('--resume', String(policy.session_id));
+    }
     if (promptPath) args.push(readFileSync(promptPath, 'utf8'));
+    else if (policy.prompt) args.push(String(policy.prompt));
     return { command: policy.command || 'claude', args };
   }
 
   if (policy.provider === 'codex-exec') {
-    const args = ['exec', ...(policy.args || [])];
+    const args = policy.session_id
+      ? ['exec', 'resume', String(policy.session_id), ...(policy.args || [])]
+      : ['exec', ...(policy.args || [])];
     if (!args.includes('--json')) args.push('--json');
     if (policy.model && !args.includes('--model')) args.push('--model', String(policy.model));
     if (policy.profile && !args.includes('--profile')) args.push('--profile', String(policy.profile));
     if (policy.output_schema && !args.includes('--output-schema')) args.push('--output-schema', String(policy.output_schema));
     if (promptPath) args.push(readFileSync(promptPath, 'utf8'));
+    else if (policy.prompt) args.push(String(policy.prompt));
     return { command: policy.command || 'codex', args };
   }
 
@@ -479,23 +555,29 @@ function runLoop(options) {
 
   if (options.adapterPolicy) {
     const policy = normalizeAdapterPolicy(loadDataFile(options.adapterPolicy), { slug });
+    const prompt = options.prompt ? { promptPath: options.prompt } : materializeStagePrompt(contract, { ...options, contractPath, slug });
     const adapterResult = runAdapter(policy, {
       dryRun: options.adapterDryRun,
-      promptPath: options.prompt,
+      promptPath: prompt.promptPath,
       stage: contract.current_stage_or_rail,
       owningGateCommand: options.owningGateCommand,
     });
-    appendLedger(ledgerPath, adapterResult.entry);
+    appendLedger(ledgerPath, { ...adapterResult.entry, prompt_path: prompt.promptPath });
     contract.terminal_status = adapterResult.status === 'gate_rerun_required' ? 'in_progress' : 'blocked';
     contract.current_stage_or_rail = adapterResult.status === 'gate_rerun_required' ? contract.current_stage_or_rail : contract.current_stage_or_rail;
+    if (adapterResult.entry && adapterResult.entry.session_id) contract.provider_session_id = adapterResult.entry.session_id;
     writeYaml(contractPath, { run_contract: contract });
     return { ...adapterResult, contractPath, ledgerPath };
   }
 
   const registryResult = executeVerifierRegistry(contract, options);
-  for (const entry of registryResult.entries) appendLedger(ledgerPath, entry);
+  let promptPath = null;
+  if (registryResult.status === 'agent_action_required') {
+    promptPath = materializeStagePrompt(contract, { ...options, contractPath, slug }).promptPath;
+  }
+  for (const entry of registryResult.entries) appendLedger(ledgerPath, promptPath ? { ...entry, prompt_path: promptPath } : entry);
   if (registryResult.advance) {
-    contract.current_stage_or_rail = nextStage(contract);
+    contract.current_stage_or_rail = nextStage(contract, options);
     contract.next_gate = `advance to ${contract.current_stage_or_rail}`;
     contract.terminal_status = contract.current_stage_or_rail === 'handoff' ? 'handoff' : 'in_progress';
   } else {
@@ -503,6 +585,68 @@ function runLoop(options) {
   }
   writeYaml(contractPath, { run_contract: contract });
   return { status: registryResult.status, contractPath, ledgerPath };
+}
+
+function readLedgerTail(ledgerPath, limit = 10) {
+  if (!existsSync(ledgerPath)) return [];
+  const lines = readFileSync(ledgerPath, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+  return lines.slice(Math.max(0, lines.length - limit)).map((line) => JSON.parse(line));
+}
+
+function runStatus(options = {}) {
+  const contractPath = options.contract;
+  if (!contractPath || !existsSync(contractPath)) {
+    return { status: 'missing_contract', error: 'specflow run status requires --contract <path>' };
+  }
+  const contract = loadRunContract(contractPath);
+  const ledgerPath = options.ledger || contract.storage?.ledger_path || join(dirname(contractPath), 'ledger.jsonl');
+  return {
+    status: 'ok',
+    contract_path: contractPath,
+    ledger_path: ledgerPath,
+    loop: contract.loop,
+    current_stage_or_rail: contract.current_stage_or_rail,
+    next_gate: contract.next_gate,
+    terminal_status: contract.terminal_status || 'unknown',
+    sequence: loopSequence(contract, options),
+    ledger_tail: readLedgerTail(ledgerPath, Number(options.limit || 10)),
+  };
+}
+
+function isTerminalStatus(status) {
+  return [
+    'agent_action_required',
+    'gate_failed',
+    'invalid_contract',
+    'adapter_unavailable',
+    'adapter_failed',
+    'blocked_human_required',
+    'dry_run',
+  ].includes(status);
+}
+
+function runUntilTerminal(options = {}) {
+  const maxIterations = Number(options.maxIterations || 8);
+  const iterations = [];
+  for (let i = 0; i < maxIterations; i += 1) {
+    const result = runLoop({ ...options, untilTerminal: false });
+    iterations.push(result);
+    if (isTerminalStatus(result.status)) {
+      return { status: result.status, iterations: i + 1, results: iterations, contractPath: result.contractPath, ledgerPath: result.ledgerPath };
+    }
+    const contract = loadRunContract(result.contractPath);
+    if (contract.terminal_status === 'handoff') {
+      return { status: 'handoff', iterations: i + 1, results: iterations, contractPath: result.contractPath, ledgerPath: result.ledgerPath };
+    }
+  }
+  const last = iterations[iterations.length - 1] || {};
+  return {
+    status: 'iteration_budget_exhausted',
+    iterations: maxIterations,
+    results: iterations,
+    contractPath: last.contractPath,
+    ledgerPath: last.ledgerPath,
+  };
 }
 
 function planAdapterSmoke(provider, options = {}) {
@@ -518,6 +662,7 @@ function planAdapterSmoke(provider, options = {}) {
     transcript_path: `.specflow/runs/adapter-smoke/${provider}.jsonl`,
     output_path: `.specflow/runs/adapter-smoke/${provider}-final.md`,
     never_without_human: ['git push', 'open PR', 'merge', '--no-verify', 'override contract'],
+    prompt: 'Reply with SPECFLOW_ADAPTER_SMOKE_OK only. Do not edit files or run commands.',
     dry_run: !options.live,
   });
   const planned = buildAdapterCommand(policy);
@@ -528,14 +673,20 @@ function cli(argv = process.argv.slice(2)) {
   const opts = parseKeyValueArgs(argv);
   const loop = opts._[0];
   if (!loop) {
-    console.error('Usage: specflow run <loop> --slug <slug> --goal <goal> --input <path> [--contract path] [--ledger path] [--adapter-policy path] [--adapter-dry-run]');
+    console.error('Usage: specflow run <loop|status> --slug <slug> --goal <goal> --input <path> [--contract path] [--until-terminal] [--max-iterations n]');
     return 2;
   }
   try {
-    const result = runLoop({ ...opts, loop });
+    const result = loop === 'status'
+      ? runStatus(opts)
+      : (opts.untilTerminal ? runUntilTerminal({ ...opts, loop }) : runLoop({ ...opts, loop }));
     if (result.status === 'invalid_contract') {
       console.error(`specflow run failed: ${result.errors.join('; ')}`);
       return 1;
+    }
+    if (result.status === 'missing_contract') {
+      console.error(result.error);
+      return 2;
     }
     console.log(JSON.stringify(result, null, 2));
     return 0;
@@ -560,11 +711,18 @@ module.exports = {
   parseProviderEvents,
   forbiddenFromProviderEvents,
   isSimulationFresh,
+  loadLoopDefinition,
+  loopSequence,
+  loopSequenceFromDefinition,
+  nextStage,
   verifierCommandsForStage,
   executeVerifierRegistry,
+  materializeStagePrompt,
   planAdapterSmoke,
   runAdapter,
   runLoop,
+  runStatus,
+  runUntilTerminal,
   cli,
 };
 

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -8,7 +8,7 @@
  */
 
 const { spawnSync } = require('child_process');
-const { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } = require('fs');
+const { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, statSync } = require('fs');
 const { dirname, join, resolve } = require('path');
 const yaml = require('js-yaml');
 
@@ -130,6 +130,136 @@ function appendLedger(ledgerPath, entry) {
   appendFileSync(ledgerPath, `${JSON.stringify({ recorded_at: new Date().toISOString(), ...entry })}\n`, 'utf8');
 }
 
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function runCommand(command, options = {}) {
+  const result = spawnSync(command, {
+    shell: true,
+    encoding: 'utf8',
+    timeout: options.timeoutSeconds ? options.timeoutSeconds * 1000 : undefined,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return {
+    command,
+    exit_code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error ? result.error.message : null,
+  };
+}
+
+function fileMtimeMs(path) {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function isSimulationFresh({ simulationPath, inputPaths = [] }) {
+  const simulationTime = fileMtimeMs(simulationPath);
+  if (!simulationTime) return { ok: false, reason: 'simulation evidence missing' };
+  const staleInput = inputPaths.find((p) => {
+    const mtime = fileMtimeMs(p);
+    return mtime && mtime > simulationTime;
+  });
+  if (staleInput) return { ok: false, reason: `simulation is older than ${staleInput}` };
+  return { ok: true, reason: null };
+}
+
+function loopSequence(contract) {
+  if (contract.loop === 'feature-build') {
+    return ['1_ticket', '2_contract', '3_e2e', '4_oracle', '5_impl', '6_provenance', '7_ci_handoff'];
+  }
+  if (contract.loop === 'spec-build') {
+    return ['discover', 'draft', 'adversary', 'GATE_A', 'tickets', 'GATE_B', 'GATE_B5', 'handoff'];
+  }
+  return [];
+}
+
+function nextStage(contract) {
+  const sequence = loopSequence(contract);
+  const index = sequence.indexOf(contract.current_stage_or_rail);
+  if (index === -1 || index === sequence.length - 1) return contract.current_stage_or_rail;
+  return sequence[index + 1];
+}
+
+function defaultSpecDir(slug) {
+  return join('docs', 'specs', slug);
+}
+
+function verifierCommandsForStage(contract, options = {}) {
+  const slug = options.slug || options.specSlug || contract.slug || 'specflow-run';
+  const specDir = options.specDir || defaultSpecDir(slug);
+  const stage = contract.current_stage_or_rail;
+  if (contract.loop === 'spec-build' && stage === 'GATE_A') {
+    return [{
+      name: 'verify-falsification',
+      command: `node scripts/verify-falsification.cjs ${shellQuote(join(specDir, 'falsification.md'))} --require-pass --binds-prd ${shellQuote(join(specDir, 'prd.md'))}`,
+    }];
+  }
+  if (contract.loop === 'spec-build' && stage === 'GATE_B') {
+    return [
+      { name: 'verify-seams', command: `node scripts/verify-seams.cjs ${shellQuote(join(specDir, 'tickets.json'))} --repo-root .` },
+      { name: 'verify-adr', command: `node scripts/verify-adr.cjs ${shellQuote(join(specDir, 'tickets.json'))} --repo-root .` },
+      { name: 'verify-ticket-journey', command: `node scripts/verify-ticket-journey.cjs ${shellQuote(specDir)} --issues ${shellQuote(join(specDir, 'issues.json'))}` },
+    ];
+  }
+  if (contract.loop === 'feature-build' && stage === '1_ticket') {
+    const simulationPath = options.simulationPath;
+    const inputPaths = (options.inputPaths || []).filter(Boolean);
+    return [{
+      name: 'simulation-freshness',
+      check: () => {
+        if (!simulationPath) return { ok: true, stdout: 'simulation freshness not configured for this run\n', stderr: '' };
+        const result = isSimulationFresh({ simulationPath, inputPaths });
+        return { ok: result.ok, stdout: result.ok ? 'simulation fresh\n' : '', stderr: result.ok ? '' : `${result.reason}\n` };
+      },
+    }];
+  }
+  if (contract.loop === 'feature-build' && stage === '6_provenance') {
+    const provenancePath = options.provenance || `evidence/provenance-${options.issue || slug}.json`;
+    return [{ name: 'provenance', command: `node scripts/provenance-gate.cjs ${shellQuote(provenancePath)}` }];
+  }
+  return [];
+}
+
+function executeVerifierRegistry(contract, options = {}) {
+  const commands = verifierCommandsForStage(contract, options);
+  if (!commands.length) {
+    return {
+      status: 'agent_action_required',
+      entries: [{
+        stage: contract.current_stage_or_rail,
+        result: 'skipped',
+        stop_reason: 'agent_action_required',
+        next_action: contract.next_gate,
+      }],
+      advance: false,
+    };
+  }
+
+  const entries = [];
+  for (const item of commands) {
+    const result = item.check ? item.check() : runCommand(item.command, options);
+    const pass = item.check ? result.ok : result.exit_code === 0;
+    entries.push({
+      stage: contract.current_stage_or_rail,
+      verifier: item.name,
+      command: item.command || item.name,
+      result: pass ? 'pass' : 'fail',
+      exit_code: item.check ? (pass ? 0 : 1) : result.exit_code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      stop_reason: pass ? null : 'gate_failed',
+    });
+    if (!pass) return { status: 'gate_failed', entries, advance: false };
+  }
+  return { status: 'gate_passed', entries, advance: true };
+}
+
 function resolveTemplate(value, context) {
   return String(value).replace(/<slug>/g, context.slug || 'run').replace(/\$\{slug\}/g, context.slug || 'run');
 }
@@ -199,6 +329,46 @@ function containsForbiddenAction(text, neverWithoutHuman = []) {
   return neverWithoutHuman.find((action) => lower.includes(String(action).toLowerCase())) || null;
 }
 
+function parseProviderEvents(provider, text) {
+  const events = [];
+  const errors = [];
+  const toolEvents = [];
+  let finalText = '';
+  let sessionId = null;
+
+  for (const line of String(text || '').split(/\r?\n/).filter(Boolean)) {
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      finalText += `${line}\n`;
+      continue;
+    }
+    events.push(event);
+    sessionId = sessionId || event.session_id || event.sessionId || event.conversation_id || event.conversationId || null;
+    const type = String(event.type || event.event || event.kind || '');
+    if (/error/i.test(type) || event.error) errors.push(event.error || event);
+    if (event.tool || event.tool_call || event.toolCall || /tool|command|exec/i.test(type)) toolEvents.push(event);
+    const textValue = event.text || event.content || event.message?.content || event.delta?.text || event.result;
+    if (typeof textValue === 'string') finalText += textValue;
+  }
+
+  return { provider, session_id: sessionId, final_text: finalText.trim(), errors, tool_events: toolEvents, events };
+}
+
+function eventText(event) {
+  return JSON.stringify(event);
+}
+
+function forbiddenFromProviderEvents(parsed, neverWithoutHuman = [], deniedTools = []) {
+  const patterns = [...neverWithoutHuman, ...deniedTools].filter(Boolean);
+  for (const event of parsed.tool_events || []) {
+    const found = containsForbiddenAction(eventText(event), patterns);
+    if (found) return found;
+  }
+  return containsForbiddenAction(parsed.final_text, neverWithoutHuman);
+}
+
 function runAdapter(policy, options = {}) {
   const planned = buildAdapterCommand(policy, options.promptPath);
   const baseEntry = {
@@ -249,7 +419,8 @@ function runAdapter(policy, options = {}) {
   const stderr = result.stderr || '';
   writeFileSync(policy.transcript_path, stdout + (stderr ? `\n${stderr}` : ''), 'utf8');
 
-  const forbidden = containsForbiddenAction(`${stdout}\n${stderr}`, policy.never_without_human);
+  const parsed = parseProviderEvents(policy.provider, `${stdout}\n${stderr}`);
+  const forbidden = forbiddenFromProviderEvents(parsed, policy.never_without_human, policy.denied_tools);
   if (forbidden) {
     return {
       status: 'blocked_human_required',
@@ -264,12 +435,15 @@ function runAdapter(policy, options = {}) {
     };
   }
 
-  writeFileSync(policy.output_path, stdout, 'utf8');
+  writeFileSync(policy.output_path, parsed.final_text || stdout, 'utf8');
   return {
     status: 'gate_rerun_required',
     entry: {
       ...baseEntry,
       exit_code: 0,
+      session_id: parsed.session_id,
+      final_response_chars: (parsed.final_text || stdout).length,
+      tool_event_count: parsed.tool_events.length,
       stop_reason: 'gate_rerun_required',
       forbidden_action_detected: false,
       owning_gate_command: options.owningGateCommand || null,
@@ -318,15 +492,36 @@ function runLoop(options) {
     return { ...adapterResult, contractPath, ledgerPath };
   }
 
-  appendLedger(ledgerPath, {
-    stage: contract.current_stage_or_rail,
-    result: 'skipped',
-    stop_reason: 'agent_action_required',
-    next_action: contract.next_gate,
-  });
-  contract.terminal_status = 'blocked';
+  const registryResult = executeVerifierRegistry(contract, options);
+  for (const entry of registryResult.entries) appendLedger(ledgerPath, entry);
+  if (registryResult.advance) {
+    contract.current_stage_or_rail = nextStage(contract);
+    contract.next_gate = `advance to ${contract.current_stage_or_rail}`;
+    contract.terminal_status = contract.current_stage_or_rail === 'handoff' ? 'handoff' : 'in_progress';
+  } else {
+    contract.terminal_status = registryResult.status === 'gate_failed' ? 'failed' : 'blocked';
+  }
   writeYaml(contractPath, { run_contract: contract });
-  return { status: 'agent_action_required', contractPath, ledgerPath };
+  return { status: registryResult.status, contractPath, ledgerPath };
+}
+
+function planAdapterSmoke(provider, options = {}) {
+  const policy = normalizeAdapterPolicy({
+    id: `${provider}-smoke`,
+    provider,
+    command: provider === 'claude-print' ? 'claude' : 'codex',
+    args: provider === 'claude-print'
+      ? ['-p', '--output-format', 'json']
+      : ['--sandbox', 'read-only', '--ask-for-approval', 'never'],
+    timeout_seconds: 120,
+    max_iterations: 1,
+    transcript_path: `.specflow/runs/adapter-smoke/${provider}.jsonl`,
+    output_path: `.specflow/runs/adapter-smoke/${provider}-final.md`,
+    never_without_human: ['git push', 'open PR', 'merge', '--no-verify', 'override contract'],
+    dry_run: !options.live,
+  });
+  const planned = buildAdapterCommand(policy);
+  return { policy, planned, live: Boolean(options.live) };
 }
 
 function cli(argv = process.argv.slice(2)) {
@@ -362,6 +557,12 @@ module.exports = {
   buildAdapterCommand,
   commandExists,
   containsForbiddenAction,
+  parseProviderEvents,
+  forbiddenFromProviderEvents,
+  isSimulationFresh,
+  verifierCommandsForStage,
+  executeVerifierRegistry,
+  planAdapterSmoke,
   runAdapter,
   runLoop,
   cli,

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -65,6 +65,7 @@ mkdir -p "$TARGET_DIR/hooks"
 mkdir -p "$TARGET_DIR/examples"
 mkdir -p "$TARGET_DIR/QA"
 mkdir -p "$TARGET_DIR/.specflow"
+mkdir -p "$TARGET_DIR/.specflow/adapter-policies"
 mkdir -p "$TARGET_DIR/.claude"
 mkdir -p "$TARGET_DIR/.codex"
 mkdir -p "$TARGET_DIR/.agents"
@@ -140,6 +141,14 @@ for example in "$SCRIPT_DIR/examples/"*; do
 done
 if [ -f "$SCRIPT_DIR/templates/journeys-template.csv" ]; then
   cp "$SCRIPT_DIR/templates/journeys-template.csv" "$TARGET_DIR/examples/"
+fi
+
+# Safe local adapter policies. Installed as dry-run templates; operators must
+# opt into live provider execution explicitly.
+if [ -d "$SCRIPT_DIR/templates/adapter-policies" ]; then
+  mkdir -p "$TARGET_DIR/.specflow/adapter-policies"
+  cp "$SCRIPT_DIR/templates/adapter-policies/"*.yml "$TARGET_DIR/.specflow/adapter-policies/" 2>/dev/null || true
+  echo -e "${GREEN}✓${NC} Installed adapter policy templates → .specflow/adapter-policies/"
 fi
 
 # Hook sources (for reference — .claude/hooks/ is installed separately)

--- a/templates/adapter-policies/claude-print.safe.yml
+++ b/templates/adapter-policies/claude-print.safe.yml
@@ -1,0 +1,32 @@
+adapter_policy:
+  id: claude-print-safe
+  provider: claude-print
+  command: claude
+  args:
+    - -p
+    - --output-format
+    - stream-json
+    - --permission-mode
+    - default
+  model: sonnet
+  max_budget_usd: 3
+  timeout_seconds: 900
+  max_iterations: 1
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+  denied_tools:
+    - Bash(git push *)
+    - Bash(gh pr create *)
+    - Bash(gh issue create *)
+    - Bash(* --no-verify *)
+  transcript_path: .specflow/runs/<slug>/adapter/claude-stage.jsonl
+  output_path: .specflow/runs/<slug>/adapter/claude-stage-final.md
+  dry_run: true
+  never_without_human:
+    - git push
+    - open PR
+    - merge
+    - --no-verify
+    - override contract

--- a/templates/adapter-policies/codex-exec.safe.yml
+++ b/templates/adapter-policies/codex-exec.safe.yml
@@ -1,0 +1,27 @@
+adapter_policy:
+  id: codex-exec-safe
+  provider: codex-exec
+  command: codex
+  args:
+    - --sandbox
+    - workspace-write
+    - --ask-for-approval
+    - never
+  model: gpt-5
+  timeout_seconds: 900
+  max_iterations: 1
+  allowed_tools: []
+  denied_tools:
+    - git push
+    - gh pr create
+    - gh issue create
+    - --no-verify
+  transcript_path: .specflow/runs/<slug>/adapter/codex-stage.jsonl
+  output_path: .specflow/runs/<slug>/adapter/codex-stage-final.md
+  dry_run: true
+  never_without_human:
+    - git push
+    - open PR
+    - merge
+    - --no-verify
+    - override contract

--- a/tests/contracts/loop-run-contract.test.js
+++ b/tests/contracts/loop-run-contract.test.js
@@ -6,7 +6,11 @@ const yaml = require('js-yaml');
 const {
   buildAdapterCommand,
   containsForbiddenAction,
+  executeVerifierRegistry,
+  forbiddenFromProviderEvents,
+  isSimulationFresh,
   normalizeAdapterPolicy,
+  parseProviderEvents,
   runAdapter,
   runLoop,
   validateRunContract,
@@ -160,6 +164,57 @@ describe('generative adapter policy and command builders', () => {
   test('detects forbidden human-gate actions in provider output', () => {
     expect(containsForbiddenAction('I will now run git push origin branch', ['git push'])).toBe('git push');
     expect(containsForbiddenAction('safe output', ['git push'])).toBe(null);
+  });
+
+  test('parses provider JSONL events into final text and tool events', () => {
+    const parsed = parseProviderEvents('codex-exec', [
+      JSON.stringify({ type: 'session', session_id: 's-1' }),
+      JSON.stringify({ type: 'message', text: 'done' }),
+      JSON.stringify({ type: 'tool_call', command: 'git push origin main' }),
+    ].join('\n'));
+
+    expect(parsed.session_id).toBe('s-1');
+    expect(parsed.final_text).toBe('done');
+    expect(parsed.tool_events).toHaveLength(1);
+    expect(forbiddenFromProviderEvents(parsed, ['git push'], [])).toBe('git push');
+  });
+});
+
+describe('stage verifier registry and freshness gates', () => {
+  test('runs Gate B verifier registry and advances only on pass', () => {
+    const dir = tempDir();
+    fs.writeFileSync(path.join(dir, 'contract.yml'), yaml.dump({
+      journeys: [{ journey_meta: { id: 'J-REGISTRY-PASS' } }],
+    }));
+    fs.writeFileSync(path.join(dir, 'issues.json'), JSON.stringify([
+      { number: 1, title: 'registry', body: 'Journey IDs: J-REGISTRY-PASS' },
+    ]));
+    fs.writeFileSync(path.join(dir, 'tickets.json'), JSON.stringify([
+      { id: 'REGISTRY-1', writes: ['verify'], reads: [], adrNone: 'no ADRs', reuses: ['scripts/verify-seams.cjs'] },
+    ]));
+
+    const result = executeVerifierRegistry({
+      loop: 'spec-build',
+      current_stage_or_rail: 'GATE_B',
+    }, { specDir: dir });
+
+    expect(result.status).toBe('gate_passed');
+    expect(result.entries.map((e) => e.verifier)).toEqual(['verify-seams', 'verify-adr', 'verify-ticket-journey']);
+  });
+
+  test('simulation freshness detects stale simulation evidence', () => {
+    const dir = tempDir();
+    const input = path.join(dir, 'ticket.md');
+    const simulation = path.join(dir, 'simulation.md');
+    fs.writeFileSync(simulation, 'old');
+    const now = new Date();
+    fs.writeFileSync(input, 'new');
+    fs.utimesSync(simulation, new Date(now.getTime() - 10000), new Date(now.getTime() - 10000));
+    fs.utimesSync(input, now, now);
+
+    const result = isSimulationFresh({ simulationPath: simulation, inputPaths: [input] });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('older');
   });
 });
 

--- a/tests/contracts/loop-run-contract.test.js
+++ b/tests/contracts/loop-run-contract.test.js
@@ -9,10 +9,15 @@ const {
   executeVerifierRegistry,
   forbiddenFromProviderEvents,
   isSimulationFresh,
+  loopSequence,
+  materializeStagePrompt,
   normalizeAdapterPolicy,
   parseProviderEvents,
+  planAdapterSmoke,
   runAdapter,
   runLoop,
+  runStatus,
+  runUntilTerminal,
   validateRunContract,
 } = require('../../scripts/specflow-runner.cjs');
 
@@ -109,6 +114,102 @@ describe('local contracted loop runner', () => {
     expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain('unsupported');
   });
+
+  test('loads stage order from loop YAML instead of only hardcoded defaults', () => {
+    const sequence = loopSequence({
+      loop: 'spec-build',
+      path: 'templates/QA/loops/spec-build.yaml',
+      current_stage_or_rail: 'GATE_B',
+    });
+
+    expect(sequence).toEqual(['discover', 'draft', 'adversary', 'GATE_A', 'tickets', 'GATE_B', 'GATE_B5']);
+  });
+
+  test('materializes a stage prompt when agent action is required', () => {
+    const dir = tempDir();
+    const contractPath = path.join(dir, 'run-contract.yaml');
+    const result = materializeStagePrompt({
+      loop: 'feature-build',
+      goal: 'finish loop runtime',
+      input_artifact: 'docs/specs/genuine-looper/prd.md',
+      path: 'templates/QA/loops/feature-build.yaml',
+      current_stage_or_rail: '5_impl',
+      next_gate: 'smallest mergeable slice',
+      durable_evidence: [contractPath],
+      stop_condition: 'handoff',
+      never_without_human: ['git push'],
+      storage: { contract_path: contractPath },
+    }, { contractPath });
+
+    expect(fs.existsSync(result.promptPath)).toBe(true);
+    expect(fs.readFileSync(result.promptPath, 'utf8')).toContain('Current stage: 5_impl');
+    expect(fs.readFileSync(result.promptPath, 'utf8')).toContain('Never without human: git push');
+  });
+
+  test('bounded run-until-terminal advances through green registries and stops at next agent stage', () => {
+    const dir = tempDir();
+    const specDir = path.join(dir, 'spec');
+    fs.mkdirSync(specDir);
+    fs.writeFileSync(path.join(specDir, 'contract.yml'), yaml.dump({
+      journeys: [{ journey_meta: { id: 'J-LOOP-RUNTIME' } }],
+    }));
+    fs.writeFileSync(path.join(specDir, 'issues.json'), JSON.stringify([
+      { number: 82, title: 'runtime', body: 'Journey IDs: J-LOOP-RUNTIME' },
+    ]));
+    fs.writeFileSync(path.join(specDir, 'tickets.json'), JSON.stringify([
+      { id: 'LOOP-RUNTIME-04', writes: ['runner'], reads: [], adrNone: 'no ADRs', reuses: ['scripts/specflow-runner.cjs'] },
+    ]));
+    const contract = path.join(dir, 'run-contract.yaml');
+    const ledger = path.join(dir, 'ledger.jsonl');
+    fs.writeFileSync(contract, yaml.dump({
+      run_contract: {
+        loop: 'spec-build',
+        goal: 'runtime',
+        input_artifact: 'docs/specs/genuine-looper/prd.md',
+        path: 'templates/QA/loops/spec-build.yaml',
+        current_stage_or_rail: 'GATE_B',
+        next_gate: 'Gate B checks',
+        durable_evidence: [contract, ledger],
+        stop_condition: 'handoff',
+        never_without_human: ['git push'],
+        storage: { contract_path: contract, ledger_path: ledger },
+      },
+    }));
+
+    const result = runUntilTerminal({ loop: 'spec-build', contract, ledger, specDir, maxIterations: 3 });
+    const saved = yaml.load(fs.readFileSync(contract, 'utf8')).run_contract;
+
+    expect(result.status).toBe('agent_action_required');
+    expect(result.iterations).toBe(2);
+    expect(saved.current_stage_or_rail).toBe('GATE_B5');
+    expect(readJsonl(ledger).some((entry) => entry.prompt_path && entry.stage === 'GATE_B5')).toBe(true);
+  });
+
+  test('run status reports the current contract and ledger tail', () => {
+    const dir = tempDir();
+    const contract = path.join(dir, 'run-contract.yaml');
+    const ledger = path.join(dir, 'ledger.jsonl');
+    fs.writeFileSync(contract, yaml.dump({
+      run_contract: {
+        loop: 'feature-build',
+        goal: 'status',
+        input_artifact: 'docs/specs/genuine-looper/prd.md',
+        path: 'templates/QA/loops/feature-build.yaml',
+        current_stage_or_rail: '6_provenance',
+        next_gate: 'provenance',
+        durable_evidence: [contract, ledger],
+        stop_condition: 'handoff',
+        never_without_human: ['git push'],
+        storage: { contract_path: contract, ledger_path: ledger },
+      },
+    }));
+    fs.writeFileSync(ledger, `${JSON.stringify({ stage: '6_provenance', result: 'pass' })}\n`);
+
+    const status = runStatus({ contract });
+    expect(status.status).toBe('ok');
+    expect(status.current_stage_or_rail).toBe('6_provenance');
+    expect(status.ledger_tail).toHaveLength(1);
+  });
 });
 
 describe('generative adapter policy and command builders', () => {
@@ -159,6 +260,32 @@ describe('generative adapter policy and command builders', () => {
     expect(command.args).toContain('--json');
     expect(command.args).toContain('--model');
     expect(command.args).toContain('--profile');
+  });
+
+  test('builds provider resume commands when a session id exists', () => {
+    const claude = buildAdapterCommand({
+      provider: 'claude-print',
+      command: 'claude',
+      args: [],
+      session_id: 'claude-session',
+      allowed_tools: [],
+      denied_tools: [],
+    });
+    const codex = buildAdapterCommand({
+      provider: 'codex-exec',
+      command: 'codex',
+      args: ['--ask-for-approval', 'never'],
+      session_id: 'codex-session',
+    });
+
+    expect(claude.args).toEqual(expect.arrayContaining(['--resume', 'claude-session']));
+    expect(codex.args.slice(0, 3)).toEqual(['exec', 'resume', 'codex-session']);
+  });
+
+  test('adapter smoke includes a bounded prompt by default', () => {
+    const smoke = planAdapterSmoke('claude-print', { live: false });
+    expect(smoke.policy.prompt).toContain('SPECFLOW_ADAPTER_SMOKE_OK');
+    expect(smoke.planned.args.join(' ')).toContain('SPECFLOW_ADAPTER_SMOKE_OK');
   });
 
   test('detects forbidden human-gate actions in provider output', () => {

--- a/tests/contracts/provenance-gate.test.js
+++ b/tests/contracts/provenance-gate.test.js
@@ -1,4 +1,4 @@
-const { auditProvenance } = require('../../scripts/provenance-gate.cjs');
+const { auditDiffText, auditProvenance } = require('../../scripts/provenance-gate.cjs');
 
 describe('provenance gate', () => {
   test('passes source-provenance rows with claims, sources, and verification', () => {
@@ -30,5 +30,20 @@ describe('provenance gate', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.violations[0]).toContain('mock/fake/stub');
+  });
+
+  test('rejects suspicious diff literals without provenance allowance', () => {
+    const result = auditDiffText([
+      'diff --git a/src/pricing.js b/src/pricing.js',
+      '+const payload = { region_code: "NOLA-LA" };', // contract-allowed negative scanner fixture
+    ].join('\n'));
+
+    expect(result.ok).toBe(false);
+    expect(result.violations[0]).toContain('value-bearing literal');
+  });
+
+  test('allows explicitly contract-approved fake provider diff lines', () => {
+    const result = auditDiffText('+const provider = "fake"; // fake provider opt-in smoke');
+    expect(result.ok).toBe(true);
   });
 });

--- a/tests/contracts/provenance-gate.test.js
+++ b/tests/contracts/provenance-gate.test.js
@@ -1,0 +1,34 @@
+const { auditProvenance } = require('../../scripts/provenance-gate.cjs');
+
+describe('provenance gate', () => {
+  test('passes source-provenance rows with claims, sources, and verification', () => {
+    const result = auditProvenance({
+      result: 'pass',
+      source_provenance: [
+        {
+          claim: 'runner writes a ledger',
+          source: 'scripts/specflow-runner.cjs',
+          verification: 'contract test re-reads ledger.jsonl',
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test('rejects empty provenance', () => {
+    const result = auditProvenance({ result: 'pass', source_provenance: [] });
+    expect(result.ok).toBe(false);
+    expect(result.violations[0]).toContain('at least one');
+  });
+
+  test('rejects unallowed mock/fake provenance', () => {
+    const result = auditProvenance({
+      result: 'pass',
+      source_provenance: [
+        { claim: 'value is right', source: 'mock adapter', verification: 'stub returned it' },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.violations[0]).toContain('mock/fake/stub');
+  });
+});

--- a/tests/hooks/installer-fixes.test.js
+++ b/tests/hooks/installer-fixes.test.js
@@ -283,6 +283,18 @@ describe('verify-setup.sh executable bit check (Bug 5 fix)', () => {
     expect(output).toContain('agents may say the specflow-loop-selector skill is unavailable');
   });
 
+  test('flags missing adapter policy templates as install failures', () => {
+    const result = spawnSync('bash', [VERIFY_PATH], {
+      encoding: 'utf-8',
+      cwd: projectDir,
+      timeout: 10000,
+    });
+
+    const output = result.stderr + result.stdout;
+    expect(output).toContain('.specflow/adapter-policies/claude-print.safe.yml missing');
+    expect(output).toContain('generative loop adapters have no safe starter policy');
+  });
+
   test('passes executable hook scripts', () => {
     for (const script of ['post-build-check.sh', 'run-journey-tests.sh', 'post-push-ci.sh']) {
       fs.writeFileSync(path.join(projectDir, '.claude', 'hooks', script), '#!/bin/bash\nexit 0');

--- a/verify-setup.sh
+++ b/verify-setup.sh
@@ -594,6 +594,15 @@ else
     check_info ".specflow/ directory not found (optional, created by post-mortem learning)"
 fi
 
+ADAPTER_POLICIES=(".specflow/adapter-policies/claude-print.safe.yml" ".specflow/adapter-policies/codex-exec.safe.yml")
+for policy in "${ADAPTER_POLICIES[@]}"; do
+    if [ -f "$policy" ]; then
+        check_pass "$policy installed"
+    else
+        check_fail "$policy missing — generative loop adapters have no safe starter policy"
+    fi
+done
+
 # Check for fix-patterns.json
 if [ -f ".specflow/fix-patterns.json" ]; then
     check_pass ".specflow/fix-patterns.json exists (post-mortem learning active)"


### PR DESCRIPTION
## Summary

Completes the remaining Specflow loop-runtime work on top of current main after #76 merged:

- bounded `specflow run --until-terminal`
- YAML-derived loop stage/rail sequence
- materialized stage prompts for generative stops
- provider session resume command support
- opt-in adapter smoke prompt
- provenance diff auditing
- `specflow run status`
- `specflow ci-status`
- install/verify coverage for loop selector skills and adapter policy templates

## Spec-build evidence

- `docs/specs/genuine-looper/prd.md`
- `docs/specs/genuine-looper/specflow-audit.md`
- `docs/specs/genuine-looper/simulation.md`
- `evidence/provenance-genuine-looper.json`

## Local verification

- `node scripts/verify-falsification.cjs docs/specs/genuine-looper/falsification.md --require-pass --binds-prd docs/specs/genuine-looper/prd.md`
- `node scripts/verify-seams.cjs docs/specs/genuine-looper/tickets.json --repo-root .`
- `node scripts/verify-adr.cjs docs/specs/genuine-looper/tickets.json --repo-root .`
- `node scripts/verify-ticket-journey.cjs docs/specs/genuine-looper --issues docs/specs/genuine-looper/issues.json`
- `node bin/specflow.js provenance evidence/provenance-genuine-looper.json --git-diff`
- `node bin/specflow.js adapter-smoke claude-print --dry-run`
- `node bin/specflow.js run spec-build --contract .specflow/runs/smoke-gateb/run-contract.yaml --ledger .specflow/runs/smoke-gateb/ledger.jsonl --spec-dir docs/specs/genuine-looper --until-terminal --max-iterations 4` advanced Gate B -> Gate B.5 and stopped at `agent_action_required`
- `npm test -- --runInBand`: 26 suites, 787 tests passed
- fresh install smoke: `specflow init` + `verify-setup.sh` returned Install failures: 0; remaining blockers were placeholder project config in the blank target
