### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to `@colmbyrne/specflow`.
 
 ---
 
+## 0.10.0 (2026-07-01)
+
+**Specflow loop runtime controls + Fable-class adapter accounting.**
+
+- **Contracted loop runner controls** — `specflow run` now carries richer adapter policy metadata for role, effort, requested model, effective/reported model, fallback, budget, usage, and cost-per-gate accounting. Silent model downgrade is no longer acceptable evidence: unknown provider metadata is recorded as `unknown`, not guessed.
+- **Compounding state memory** — loop runs can write `.specflow/STATE.md` and one-lesson-per-file memory under `.specflow/lessons/`; generated stage prompts include a bounded state digest so later runs resume from durable facts instead of chat memory.
+- **Delegation and routines** — added isolated worktree preparation metadata and `specflow routine <slug>` manifest scaffolding for cron/GitHub/hosted loops. Generated routines call `specflow run` and preserve `never_without_human`.
+- **Gate D vision evidence** — `teardown-gate check-gate-d` accepts screenshot plus vision-verifier finding evidence while still requiring value-bearing `.txt`/`.json` oracle re-reads for value hops.
+- **Install/package fix** — `js-yaml` is now a production dependency because the published CLI loads YAML at runtime.
+
+---
+
 ## 0.9.1 (2026-06-12)
 
 **Conditional ADR-conformance + universal component-reuse check (#68).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,22 @@
 {
-  "name": "specflow-test-harness",
-  "version": "1.0.0",
+  "name": "@colmbyrne/specflow",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "specflow-test-harness",
-      "version": "1.0.0",
+      "name": "@colmbyrne/specflow",
+      "version": "0.10.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.3.0"
+      },
+      "bin": {
+        "specflow": "bin/specflow.js"
+      },
       "devDependencies": {
-        "jest": "^29.7.0",
-        "js-yaml": "^4.1.0"
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1104,7 +1111,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
@@ -2692,10 +2698,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colmbyrne/specflow",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Specs that enforce themselves. Contract tests, journey hooks, and agent orchestration for LLM-driven development.",
   "license": "MIT",
   "repository": {
@@ -43,7 +43,9 @@
     "verify:graph": "node scripts/verify-graph.cjs"
   },
   "devDependencies": {
-    "jest": "^29.7.0",
-    "js-yaml": "^4.1.0"
+    "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Hulupeep/Specflow.git"
+    "url": "git+https://github.com/Hulupeep/Specflow.git"
   },
   "bin": {
     "specflow": "bin/specflow.js"


### PR DESCRIPTION
## Summary

Prepare `@colmbyrne/specflow` `0.10.0` for publication after the merged loop-runtime/Fable-class adapter work.

## Release notes

- Adds loop runtime controls and richer adapter model/accounting metadata.
- Adds compounding state memory notes for `.specflow/STATE.md` and `.specflow/lessons/`.
- Adds routine manifest scaffolding for cron/GitHub/hosted loops.
- Adds Gate D vision evidence support while preserving value-bearing oracle evidence requirements.
- Moves `js-yaml` into production dependencies because the CLI loads YAML at runtime.

## Verification

- `npm test -- --runInBand` passed on merged main plus release metadata.
- `npm pack` produced `colmbyrne-specflow-0.10.0.tgz`.
- Clean temp install smoke passed:
  - `npx @colmbyrne/specflow init .`
  - `npx @colmbyrne/specflow verify`
  - verify reported `Install failures: 0`; remaining blockers were blank-project CLAUDE.md placeholders.
- Confirmed installed assets:
  - `.claude/.codex/.agents` loop selector skill files
  - `.specflow/adapter-policies/claude-print.safe.yml`
  - `.specflow/adapter-policies/codex-exec.safe.yml`
  - `scripts/teardown-gate.cjs`
- `npx @colmbyrne/specflow routine smoke-release-010 --kind cron --loop spec-build --input docs/idea.md` generated the expected routine manifest.
- Installed `node scripts/teardown-gate.cjs check-gate-d gate-d/smoke` passed against a minimal smoke Gate D evidence folder.
- `npm publish --dry-run` passed for `@colmbyrne/specflow@0.10.0`.

## Publish status

Actual `npm publish` is blocked in this environment because `npm whoami` returns `E401 Unauthorized`. Publish can proceed after npm authentication and after this release metadata is merged or otherwise accepted.
