### PR TITLE
Add loop-talk adjustment tickets

### DIFF
--- a/docs/specs/fable-loop-compounding/contract.yml
+++ b/docs/specs/fable-loop-compounding/contract.yml
@@ -14,6 +14,12 @@ requirements:
     statement: Teardown/Gate D can record screenshot plus vision-verifier evidence without making vision the gate of record.
   - id: REQ-COST-01
     statement: Loop ledger records model usage and cost-per-accepted-change counters when available.
+  - id: REQ-VERIFIER-02
+    statement: Feature-build negotiates a slice-local verification contract and can run adversarial runtime verification before gate advance.
+  - id: REQ-TRACE-01
+    statement: Operators can generate a divergence report from ledger, transcript, provider, verifier, and gate evidence.
+  - id: REQ-HARNESS-MINIMAL-01
+    statement: Provider-specific scaffolding stays thin, ledger-backed, and removable while mechanical gates remain durable.
 journeys:
   - journey_meta:
       id: J-FABLE-MODEL-ROUTING
@@ -117,3 +123,53 @@ journeys:
     then:
       - token/cost fields are stored when available
       - status output summarizes gate attempts, accepted gates, rejected gates, and cost-per-accepted-change
+
+  - journey_meta:
+      id: J-FABLE-VERIFIER-NEGOTIATION
+      persona: feature_builder
+      owner_ticket: VERIFIER-02
+      assertion_bar: accepted verification contract exists before maker implementation and runtime verifier evidence is subordinate to mechanical gates
+    scenario: negotiate done criteria and run an adversarial product verifier
+    given:
+      - a feature-build slice has an outer ticket contract and journey IDs
+      - the provider policy declares a separate verifier
+    when:
+      - the maker proposes the slice-local verification contract
+      - the verifier rejects vague or missing runtime checks until the contract is executable
+      - the maker implements against the accepted contract
+    then:
+      - the accepted verification contract is persisted under the run directory
+      - the verifier runs against artifact plus contract, not maker reasoning trace
+      - runtime evidence can include Playwright steps, screenshot refs, console logs, network logs, and value re-reads
+      - the gate does not advance until the owning mechanical verifier or journey test passes
+
+  - journey_meta:
+      id: J-FABLE-TRACE-REVIEW
+      persona: loop_operator
+      owner_ticket: TRACE-01
+      assertion_bar: divergence report re-reads ledger entries and transcript/evidence references without provider summarization by default
+    scenario: debug a long-running loop from persisted traces
+    given:
+      - a run directory contains `ledger.jsonl`, run contract, maker transcript refs, verifier refs, and gate results
+    when:
+      - the operator runs `specflow run trace <run-dir>`
+    then:
+      - the report groups attempts by stage and disposition
+      - maker/verifier/gate divergence is highlighted
+      - missing transcripts and dangling evidence refs are reported as missing
+      - no transcript content is sent to a provider unless explicitly requested
+
+  - journey_meta:
+      id: J-FABLE-HARNESS-MINIMAL
+      persona: maintainer
+      owner_ticket: HARNESS-MINIMAL-01
+      assertion_bar: status and docs distinguish durable trust fields from transient provider knobs
+    scenario: remove stale model scaffolding without weakening gates
+    given:
+      - provider capabilities change and a policy knob becomes unsupported or consistently unknown
+    when:
+      - Specflow validates adapter policy and renders status
+    then:
+      - durable trust fields remain recorded in the ledger
+      - stale or unsupported provider knobs are visible to maintainers
+      - no mechanical gate depends on effort tier, brand name, or cost estimate alone

--- a/docs/specs/fable-loop-compounding/falsification.md
+++ b/docs/specs/fable-loop-compounding/falsification.md
@@ -1,6 +1,6 @@
 # Falsification Pass - fable-loop-compounding
 
-PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
+PRD SHA-256: 71f99b621acce4d0d12f3f027aac1574898fd7b0edc76214e5e1c1214371c5fb
 
 ## Premise Attack
 | Premise | Source | Could be false because | Verdict | Required correction |
@@ -10,6 +10,10 @@ PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
 | `/loop` and routines need Specflow manifests | User-provided routine guidance and existing loop docs | Provider-native routines may already encode triggers | Holds | Manifest calls `specflow run` and preserves stop rules |
 | Memory should compound through state and lessons | User guidance and current ledger behavior | Existing ledger may be sufficient for resume | Holds | State file is summary/resume; ledger remains evidence |
 | External reviewer providers improve Fable output | User guidance | External reviewer may be wrong or unavailable | Holds with stipulation | Treat external review as evidence only, never gate authority |
+| Stronger models need less up-front implementation detail | Anthropic loop-talk evaluation | Brownfield compliance work still needs durable pre-implementation contracts | Holds with boundary | Keep spec-build as outer WHAT contract; move HOW-verified detail into feature-build negotiation |
+| Runtime verification catches failures static gates miss | Anthropic loop-talk evaluation | Runtime verifiers may hallucinate or only inspect screenshots | Holds with stipulation | Runtime verifier evidence is subordinate to mechanical journey/gate checks |
+| Trace review is necessary for long-running loops | Anthropic loop-talk evaluation | Trace tooling could leak transcripts to providers or summarize away evidence | Holds with stipulation | Default to local-only reports; provider summarization is opt-in and ledgered |
+| Harness scaffolding should be removable | Anthropic loop-talk evaluation | Removing scaffolding could weaken gates | Holds with boundary | Only provider-specific scaffolding is disposable; mechanical gates and human stops remain durable |
 
 ## Claim Inventory
 | Claim | Type | Source support | Load-bearing? | Status | What breaks downstream if wrong | Correction |
@@ -28,6 +32,10 @@ PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
 | Independent verifier -> safer Fable output | Maker self-critique is weak | Verifier can become another self-attestation | Holds | Mechanical gates remain required |
 | Routine manifests -> scheduled loops | Cron/hosted triggers need consistent contract | Routine could bypass human gates | Holds | Manifest inherits `never_without_human` |
 | Vision evidence -> UI/Gate D quality | Visual tasks need screenshot review | Vision model could hallucinate | Holds | teardown-gate validates files and value re-reads |
+| Maker/verifier negotiation -> better slice quality | Fine-grained done criteria should be negotiated at build time | Negotiation could become another unreviewed model conversation | Holds | Accepted contract is written to run directory before maker work and re-read by later gates |
+| Runtime verifier -> behavioral coverage | Static gates can miss live UI/API behavior | Runtime verifier may pass without mechanical proof | Holds | Runtime verdict is evidence only; journey/mechanical gate remains authoritative |
+| Trace report -> debuggability | Long loops need ledger/transcript/gate divergence surfaced | Trace report could invent missing evidence | Holds | Unknown/missing/dangling fields must be reported, not inferred |
+| Harness-minimality -> lower long-term complexity | Model-specific knobs drift quickly | Removing knobs could erase audit data | Holds | Ledger preserves durable trust fields; only stale provider knobs are removable |
 
 ## Acceptance Gate Attack
 | Gate | How it could be gamed | Missing oracle | Correction |
@@ -39,6 +47,10 @@ PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
 | Routine | Scheduled job runs a different process | Manifest command inspection | AC requires `specflow run` command |
 | Vision gate | Screenshot exists but no goal comparison | Finding file | AC requires vision finding evidence |
 | Cost | Missing usage gets fabricated | Unknown marker | AC requires unknown when unavailable |
+| Maker-verifier negotiation | Verifier accepts vague "looks good" criteria | Accepted verification contract file | AC requires pre-maker contract persisted under run directory |
+| Runtime verifier | Runtime model claims it drove the app but no app evidence exists | Playwright/log/screenshot/value evidence | AC requires runtime evidence and mechanical gate rerun |
+| Trace review | Summary hides failed tool calls or missing transcripts | Ledger/transcript/evidence cross-reference | AC requires divergence and missing refs to be explicit |
+| Harness minimality | Effort tier/model brand becomes a gate proxy | Durable trust field split | AC forbids gates depending solely on provider effort/model/cost |
 
 ## Source / Reality Ledger
 | Concrete claim | Verified against (file / query) | Holds? | Evidence |
@@ -48,6 +60,8 @@ PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
 | Ledger path exists in tests | `tests/contracts/loop-run-contract.test.js` | Yes | `ledger.jsonl` assertions |
 | teardown-gate validates Gate D evidence | `scripts/teardown-gate.cjs` | Yes | `check-gate-d` command |
 | Routine/mistake-harvest concept exists in docs | `templates/QA/loops/README.md`, `templates/process/PROCESS-CODEX.md` | Yes | routine text is present |
+| Runner records run status from ledger | `scripts/specflow-runner.cjs` | Yes | `runStatus` |
+| Provider event parsing is a named runner surface | `scripts/specflow-runner.cjs` | Yes | `parseProviderEvents` |
 
 ## Overclaim / Scope Leakage
 | Text | Why it overclaims | Replacement text |
@@ -56,6 +70,10 @@ PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
 | External reviewer proves correctness | Reviewer is still model output | External review is evidence before mechanical gates |
 | STATE.md makes the model learn | Weights do not change | State/lessons make the surrounding system compound |
 | `/loop` is universally available | Provider-specific surface | Routine manifest can include `/loop` where supported |
+| A stronger model means more spec-build detail is safer | More up-front detail can cascade planner errors | Spec-build owns WHAT and hard constraints; feature-build negotiates HOW-verified per slice |
+| Runtime verifier proves correctness | Verifier is still fallible provider/tool evidence | Runtime verification is evidence subordinate to mechanical gates |
+| Trace review can summarize transcripts by default | Provider summarization can leak or distort evidence | Trace review is local-only by default; provider summarization is opt-in and ledgered |
+| Model effort labels are product doctrine | Provider labels change quickly | Effort labels are transient policy metadata, not gate criteria |
 
 ## Banned-Mode Self-Check
 | Banned mode | Present? | Evidence / note |
@@ -70,4 +88,4 @@ PRD SHA-256: 2bf63f432d1acc0b8d67507435d5d014b631a146ac55acd986505fc8b5b7ba13
 
 ## Final Verdict
 
-PASS WITH STIPULATIONS. Owner: feature-build implementers must keep provider-specific effort and `/loop` fields optional, validate supported provider surfaces at runtime, and keep mechanical gates authoritative.
+PASS WITH STIPULATIONS. Owner: feature-build implementers must keep provider-specific effort and `/loop` fields optional, validate supported provider surfaces at runtime, keep mechanical gates authoritative, persist maker-verifier contracts before implementation, and keep trace review local-only by default.

--- a/docs/specs/fable-loop-compounding/hops.md
+++ b/docs/specs/fable-loop-compounding/hops.md
@@ -9,6 +9,9 @@
 | J-FABLE-ROUTINE-MANIFEST | `specflow run` | scaffolded manifest | Manifest command re-reads `/loop` interval where supported, `specflow run`, `never_without_human`, and spec-build routing for project-improvement proposals. | CLI test |
 | J-FABLE-VISION-EVIDENCE | `teardown-gate` | Gate D/teardown evidence | Evidence file exists and value-bearing re-read remains mandatory. | teardown-gate test |
 | J-FABLE-COST-ACCOUNTING | `ledger.jsonl` | adapter completion | Status re-reads requested/effective model and cost counters without inventing missing usage. | Status test |
+| J-FABLE-VERIFIER-NEGOTIATION | `run_contract` | feature-build negotiation | Accepted slice-local verification contract exists before maker implementation; runtime verifier evidence is subordinate to mechanical gates. | Runner + journey test |
+| J-FABLE-TRACE-REVIEW | `ledger.jsonl` | `specflow run trace` | Trace report re-reads ledger, transcript refs, provider events, verifier entries, and gate results without default provider summarization. | CLI trace test |
+| J-FABLE-HARNESS-MINIMAL | `adapter_policy` | policy validation/status | Status distinguishes durable trust fields from transient provider knobs and flags stale/unknown fields without making them gates. | Policy/status test |
 
 ## Seam-Derived Hops (Gate B)
 
@@ -17,8 +20,10 @@ These hops were derived by `node scripts/verify-seams.cjs docs/specs/fable-loop-
 | Seam surface | Pair set | Kind | Required re-read assertion |
 |---|---|---|---|
 | `.specflow` | ROUTINE-01, STATE-01 | writer-writer | A scheduled/routine run and the memory writer agree on the same `.specflow` layout, without one hiding or overwriting the other's state. |
-| `adapter_policy` | COST-01, MODEL-ROUTING-01, VERIFIER-01 | mixed | Adapter policy re-reads preserve model role, effort, requested/effective model, fallback/refusal reason, budget, verifier, and external-review fields in one normalized policy shape. |
-| `ledger.jsonl` | COST-01, MODEL-ROUTING-01, ROUTINE-01, STATE-01, VERIFIER-01, WORKTREE-01 | writer-writer | A merged run ledger records all new stage, model, verifier, routine, worktree, memory, and cost events as append-only structured entries. |
-| `run_contract` | WORKTREE-01, ROUTINE-01, STATE-01 | writer-reader | Worktree and routine execution re-read the same run contract state that memory compaction uses to resume the next stage. |
-| `runAdapter` | VERIFIER-01, COST-01, MODEL-ROUTING-01 | writer-reader | Adapter execution preserves maker/verifier separation while exposing enough normalized provider data to distinguish requested model, effective model, fallback/refusal reason, routing, and cost accounting. |
-| `runStatus` | COST-01, WORKTREE-01 | writer-reader | Status output re-reads cost counters and delegated worktree state without inventing missing provider usage. |
+| `adapter_policy` | COST-01, HARNESS-MINIMAL-01, MODEL-ROUTING-01, VERIFIER-01, VERIFIER-02 | mixed | Adapter policy re-reads preserve model role, effort, requested/effective model, fallback/refusal reason, budget, verifier, transient provider knobs, and external-review fields in one normalized policy shape. |
+| `ledger.jsonl` | COST-01, MODEL-ROUTING-01, ROUTINE-01, STATE-01, TRACE-01, VERIFIER-01, VERIFIER-02, WORKTREE-01, HARNESS-MINIMAL-01 | mixed | A merged run ledger records all stage, model, verifier, routine, worktree, memory, trace, harness-minimality, and cost events as append-only structured entries. |
+| `run_contract` | VERIFIER-02, WORKTREE-01, ROUTINE-01, STATE-01, TRACE-01 | mixed | Worktree, routine, state, trace, and negotiated verifier execution re-read the same run contract state before advancing. |
+| `runAdapter` | VERIFIER-01, VERIFIER-02, COST-01, HARNESS-MINIMAL-01, MODEL-ROUTING-01 | mixed | Adapter execution preserves maker/verifier separation while exposing enough normalized provider data to distinguish requested model, effective model, fallback/refusal reason, routing, cost, and stale scaffolding. |
+| `runStatus` | COST-01, HARNESS-MINIMAL-01, TRACE-01, WORKTREE-01 | mixed | Status output re-reads cost counters, trace divergence, stale/unknown policy fields, and delegated worktree state without inventing missing provider usage. |
+| `teardown-gate` | VISION-GATE-01, VERIFIER-02 | writer-reader | Runtime and vision verifier evidence re-read through Gate D/teardown evidence rules, with value-bearing evidence still mandatory. |
+| `verifier` | VERIFIER-01, VERIFIER-02, TRACE-01 | mixed | Maker/verifier negotiation, independent verifier output, and trace review agree on artifact-plus-rubric evidence without exposing maker reasoning trace as verifier input. |

--- a/docs/specs/fable-loop-compounding/issues.json
+++ b/docs/specs/fable-loop-compounding/issues.json
@@ -33,5 +33,20 @@
     "number": 89,
     "title": "[SPECFLOW] COST-01: model usage and cost-per-accepted-change counters",
     "body": "Journey IDs: J-FABLE-COST-ACCOUNTING\n\nSee docs/specs/fable-loop-compounding/tickets.md for the local ticket packet."
+  },
+  {
+    "number": 92,
+    "title": "[SPECFLOW] VERIFIER-02: maker-verifier negotiation and runtime verification",
+    "body": "Journey IDs: J-FABLE-VERIFIER-NEGOTIATION\n\nSee docs/specs/fable-loop-compounding/tickets.md for the local ticket packet."
+  },
+  {
+    "number": 93,
+    "title": "[SPECFLOW] TRACE-01: run trace divergence report for long-running loops",
+    "body": "Journey IDs: J-FABLE-TRACE-REVIEW\n\nSee docs/specs/fable-loop-compounding/tickets.md for the local ticket packet."
+  },
+  {
+    "number": 94,
+    "title": "[SPECFLOW] HARNESS-MINIMAL-01: keep model scaffolding thin and removable",
+    "body": "Journey IDs: J-FABLE-HARNESS-MINIMAL\n\nSee docs/specs/fable-loop-compounding/tickets.md for the local ticket packet."
   }
 ]

--- a/docs/specs/fable-loop-compounding/long-running-agents-evaluation.md
+++ b/docs/specs/fable-loop-compounding/long-running-agents-evaluation.md
@@ -1,0 +1,136 @@
+# Evaluating Anthropic's "Building Long-Running Agents" Against Specflow's Loop Runtime
+
+**Date:** 2026-07-01
+**Author:** Analysis for the `fable-loop-compounding` work (#83–89)
+**Talk source:** Anthropic applied-AI talk transcript captured locally during analysis. The raw transcript is intentionally not stored in this repository; citations below use the talk's section titles and timestamps, e.g. *(§ "The generator-evaluator contract", ~24:56)*.
+
+---
+
+## 1. Context
+
+The talk is an Anthropic applied-AI session (Andrew + Ash) on harnesses for agents that run for hours-to-days. First half is a history of Claude Code primitives; second half is the current state-of-the-art harness pattern: a **planner → generator → evaluator** loop with adversarial pressure, file-system state, and granular contracts.
+
+Our recent work is the same problem from the other side. The local runtime lives in `scripts/specflow-runner.cjs` (the `specflow run` command: `spec-build` / `feature-build` loops, `run-contract.yaml`, `ledger.jsonl`, `claude-print`/`codex-exec` adapter policies, a verifier registry, `never_without_human` enforcement, `--until-terminal`). The `fable-loop-compounding` packet (#83–89, branch `specbuild/fable-loop-compounding`) is **explicitly our response to this talk** — its PRD goal is *"Adapt Specflow for stronger long-horizon agent models without weakening gates"* and treats "Fable-class models as high-capability workers and orchestrators, not as trusted gates."
+
+This document evaluates how well that packet — and the runtime it extends — lines up with what Anthropic actually reported, where we're ahead, where we diverge, and what to change.
+
+**Bottom line:** the talk is strong external validation of Specflow's core bet (granular contracts + file-system state + no self-grading), and #83–89 is the right set of moves. But there is one philosophical tension to resolve on purpose (planner granularity), and two gaps the packet does not cover (a verifier that drives the running product; trace-review tooling).
+
+---
+
+## 2. What the talk validates about what we already shipped
+
+Three existing Specflow invariants are the talk's hard-won lessons, arrived at independently:
+
+1. **"Self-evaluation is a trap — use an adversarial evaluator."** *(§ "Key takeaways for long-running agents", ~38:56; § "The evolution…", the GAN framing ~18:27–20:42)* → our `I-ADAPTER-001`: *"a provider process exit code is never a Specflow gate result"* and `I-LOOP-002`. We already refuse to let the generator grade itself.
+   - **We're ahead here.** Their evaluator is still an LLM and is *sycophantic out of the box* — they spent "an exorbitant amount of time" tuning it *(§ "Specificity in contracts and debugging traces", ~32:40)*. Our mechanical gates (`verify-seams`, `verify-adr`, `provenance-gate`) are deterministic scripts and **cannot be flattered**. Wherever the gate is mechanical, we sidestep their single hardest failure mode.
+
+2. **"Compaction ≠ coherence — use the file system for shared state."** *(§ "Key takeaways…", ~39:09; § "How to build your own…", ~36:26; breadcrumb JSON state, ~54:54)* → our `run-contract.yaml` + `ledger.jsonl` + resumable `runUntilTerminal`. Their "leave breadcrumbs (tried X, found bug, fix worked ✓)" log *is* our ledger. Their note that **models overwrite markdown but not JSON** *(§ "First long-running agent patterns", `feature_list.json`, ~12:34)* validates our `.jsonl` choice for machine state.
+
+3. **"Granular criteria → actionable critique; vague criteria → the generator shrugs."** *(§ "Specificity in contracts and debugging traces", "27 contract criteria", ~32:04)* → Specflow's entire thesis (named invariants, ACs, journey IDs). They reinvented our contract granularity as the thing that made long runs work.
+
+One place we are **stricter than the talk, correctly**: in their GAN loop the evaluator's verdict effectively *is* the gate. In Specflow every LLM judgment is **evidence subordinate to a mechanical gate** (#84: "Gate advance remains blocked until the owning script/verifier gate passes"; #88: "vision verdict is evidence, not self-attested gate pass"). This is a better answer to their own unsolved sycophancy problem. Keep it.
+
+---
+
+## 3. Ticket-by-ticket mapping (#83–89)
+
+| Ticket | Talk lesson it implements | Citation | Verdict |
+|---|---|---|---|
+| **#84 VERIFIER-01** | Generator/evaluator split. "Verifier input is artifact + rubric, **not maker reasoning trace**" is verbatim their Q&A answer. | § generator-evaluator contract ~24:56; Q&A ~1:00:05 ("feeding the trace muddies the two model streams; let it judge the output") | Right idea, **underscoped** — §4, §5. |
+| **#85 STATE-01** | File-system state + breadcrumbs; STATE.md sections map 1:1 to their tried/fixed/worked log. "Don't save facts already in repo/contracts/transcripts." | § "Key takeaways…" ~39:09; breadcrumbs ~54:54 | Correct. Machine state in jsonl, STATE.md append-only. |
+| **#86 WORKTREE-01** | Git worktrees for parallel maker/verifier without file collisions. | Q&A ~1:07:04 (Andrew: "git work trees so you're not overwriting the file system") | Correct and durable. |
+| **#83 MODEL-ROUTING-01** | "Opus for planning, Sonnet as workhorse"; model selection informs harness. Our "silent downgrade = failed contract" honesty rule goes **beyond** the talk. | § "Opus 4.5 and the role of sub-agents" ~11:02; Q&A model-selection-informs-harness ~53:07 | Split value — see §6 (co-evolution risk). |
+| **#87 ROUTINE-01** | Their long runs live on remote servers via the Agent SDK, **not** Claude Code on a laptop. Our REQ-05B ("hosted scheduling out of scope for the local runner") + "all variants call `specflow run`, no parallel loop process" is the posture they endorse. | Q&A ~57:10–58:24 (Agent SDK for cloud/sandboxed runs; "caffeinate on your machine") | Correct posture; resist scope creep. |
+| **#88 VISION-GATE-01** | Evaluator opening live pages / screenshots / vision. Partial coverage of "evaluator uses the app." | § "…experimental work… design taste" ~22:22; play-mode demo ~30:33 | Correct but narrow (UI-only). |
+| **#89 COST-01** | The "$200 / six hours… half the cost" thread; cost-per-accepted-change. | § retro-game demo ~29:02; § "Adjusting harnesses…" ~36:39 | Prudent; transient — see §6. |
+
+---
+
+## 4. The core tension: planner granularity
+
+This is the talk's **biggest architectural claim**, and it cuts against Specflow's grain, so decide it deliberately.
+
+> The planner should be *deliberately high-level* — set creative direction and hard outer lines only. It must **not** plan granular technical details, because a planner error "cascades through every single one of these sprints and magnifies errors over a multi-hour time horizon." The granular, testable assertions get **negotiated at build time between the generator and evaluator**, written to disk, and the evaluator grades against *that* contract — "not the original spec which the planner has one-shotted."
+> — *§ "Introducing the 'Planner' role", ~23:45; § "The generator-evaluator contract", ~24:56*
+
+They frame this explicitly as the fix for **both** Ralph's fixed `plan.md` *and their own earlier harness* — an initializer that pinned ~200 features up front and was then "forced into" bad design decisions *(Q&A ~52:45)*. Their headline finding: **the stronger the model, the *less* you should pre-specify.**
+
+Specflow's `spec-build` is the opposite. It front-loads prd + tickets + falsification + seams + ADR + journeys + simulation, then `feature-build` executes against that pinned plan. Structurally, **that is the *old* Anthropic harness they moved away from.**
+
+**Reasoning about why this is still fine for us — and where to bend:**
+
+- Our defense is legitimate and the talk concedes it. Specflow targets brownfield, multi-session, team, auditable, no-ticket-no-code, CI-enforced work, where a *durable pinned contract is the product* (traceability, compliance, PR-blocking). Their harness is greenfield one-shot demos where nobody audits *why*. They admit brownfield "needs more control… custom rubrics" and is "more suited towards brand-new applications" *(Q&A ~1:11:00)*. So we do **not** throw out spec-build.
+- But absorb the lesson by moving where granularity lives:
+  - Keep **ticket ACs / invariants / `never_without_human`** as the durable *outer* contract (creative direction + hard constraints).
+  - Push the fine-grained "what does *done* mean for this slice, tested how" into a **maker↔verifier negotiation sub-stage inside #84**, written to disk *before* the maker builds. That back-and-forth ("scope too big, tests too weak, you missed edge case Z") is *the one primitive the talk says Ralph never had*, and #84 currently under-specifies it — it reads as a static plan reviewer, not a negotiation.
+- Practical guardrail: resist the urge to pin more detail in spec-build "because the model is stronger." The talk's evidence says that magnifies cascade errors. Spec-build owns the **WHAT** (journeys, invariants, forbidden actions); #84 owns the **HOW-verified**.
+
+---
+
+## 5. Two gaps the packet misses
+
+**Gap 1 — the verifier must drive the running product, not just check artifacts.** *(Highest leverage.)*
+Their evaluator uses Playwright/vision to *actually play the game, press the arrow keys, read console and network errors* — and that is what caught route-ordering, boolean-logic, and "space bar does nothing" bugs that a Ralph loop's CI sailed past *(§ retro-game play-mode ~30:33–31:18; "the evaluator actually launched the game, tried to play it" ~30:58)*. Our verifiers are mostly **static** (grep-like scripts, schema, provenance); #88 adds UI vision but only at teardown/Gate D.
+→ **Broaden #84** so a verifier policy can name an *adversarial runtime verifier* that exercises the built thing against a granular, weighted rubric — and instruct it to default to **refute/harsh** (their explicit counter to LLM-verifier sycophancy, § ~32:40). "External plan reviewer / Oracle" is the weakest, most static form of what they demonstrated.
+
+**Gap 2 — trace-review tooling.**
+The talk's #1 practical claim is that the primary debugging loop is **reading transcripts by hand**; piping them to another agent is only a "first pass," and observability for long runs is unsolved green-field software *(§ "Specificity…" ~33:26; Q&A ~1:01:25 "read the whole thing"; Q&A ~1:06:45 observability unsolved)*. We produce the ideal artifact for this (`ledger.jsonl` + `transcript_path`) but ship **zero** tooling to triage it or surface where the maker's judgment diverged from the gate.
+→ Clean candidate **#90**: a `specflow run trace` / divergence report. No current ticket covers the single most-used debugging practice in the talk.
+
+---
+
+## 6. Co-evolution risk (applies to #83, #89)
+
+Their closing meta-lesson is a warning against exactly the elaborate config #83/#89 add:
+
+> "The lesson isn't our harness was wrong, but rather it was right for 4.5 — the frontier moved." They *dropped* context-resetting and per-sprint evaluator cadence once 4.6 could hold a two-hour coherent build. "Get a feel for the spiky behaviors of any individual model, then adapt your harness to fill the gaps… I'd be hunting for the model release where I can strip it out."
+> — *§ "Adjusting harnesses as models evolve", ~34:14–36:08*
+
+Sort the original seven tickets by **durability**, not just alignment:
+
+- **Model-independent trust primitives — build with confidence:** #84 (verifier separation), #85 (state/lessons), #86 (worktree isolation), plus the existing `never_without_human` guardrails. These survive any model generation.
+- **Durable core inside a transient wrapper:** #83's *honesty* rule (requested-vs-effective model; silent-downgrade = failed contract) is durable; the effort-tier taxonomy (`low/high/xhigh/ultracode`) and #89's cost-per-change dashboards are the scaffolding most likely to be obsoleted by a cheaper/more-honest next model. Build them thin, keep them behind the ledger, be willing to delete.
+
+Add one line to the PRD operating model: *the harness stays minimal and gate-centric, and scaffolding is removed as models improve.* Today the PRD says "without weakening gates" (the safety half) but not the "strip it back" half.
+
+---
+
+## 7. Values divergence — keep ours; it's a feature
+
+The talk's posture favors high-autonomy runs: minimize human checkpoints, bake fixes into the harness, and use hooks only for stop conditions *(Q&A ~1:08:17)*. Specflow's `never_without_human` (push/PR/merge/`--no-verify`/override, **mechanically** enforced from provider events via `forbiddenFromProviderEvents`) is the opposite by design. Do **not** converge on their default.
+
+Their own answer to "what if I want to review mid-run" is "implement hooks at a stop condition" — our `never_without_human` *is* that hook, made declarative and enforced. The fable PRD non-goals ("auto-trusting Fable output as a gate," "routines pushing/merging without approval") are the correct guardrails and directly counter the talk's more permissive posture. For brownfield/team/production work, our stance is more appropriate than theirs.
+
+---
+
+## 8. Top recommendations (ranked)
+
+1. **Broaden #84 before building it.** Add (a) a **maker↔verifier contract-negotiation sub-stage** written to disk before the maker builds, and (b) an **adversarial *runtime* verifier** (Playwright/vision-driven, harsh weighted rubric, defaults to refute), not just an external plan reviewer. Keep "artifact + rubric, not maker trace." *This is the talk's core and our biggest current gap.*
+2. **Ship #85 + #86 next.** Durable, model-independent, low regret. Keep machine state in `jsonl` (overwrite-resistant), `STATE.md` append-only, and enforce the "don't duplicate repo/contract/transcript facts" AC.
+3. **Open #90: trace-review tooling.** A `specflow run trace` / divergence report over `ledger.jsonl` + transcripts. It's the #1 debugging practice in the talk and nothing covers it.
+4. **Build #83 / #89 thin.** Implement the honesty/ledger parts; keep the effort-tier taxonomy and cost dashboards minimal and disposable. Add the "strip scaffolding as models improve" line to the PRD.
+5. **Hold the conservative line on #87 / #88.** No parallel scheduler (all variants call `specflow run`); vision/routines are evidence-only and cannot bypass human gates. The talk confirms hosted/background execution belongs to the Agent SDK, not the local runner.
+6. **Reaffirm the trust boundary as a headline, not a footnote.** Our mechanical gate + `never_without_human` is the answer to the two hardest unsolved problems in the talk (sycophantic self-grading; human-in-the-loop for high-stakes work). Lead with it in README/positioning.
+
+---
+
+### Appendix — key talk citations
+
+| Claim | Talk location |
+|---|---|
+| Self-eval is a trap → adversarial evaluator | § "Key takeaways…", ~38:56; GAN framing ~18:27 |
+| Tuning a harsh standalone critic is tractable; a self-critical builder is not | ~19:50–20:42 |
+| Subjective quality is gradable via a weighted rubric (design/originality/craft/functionality) | § "Evaluating subjective output with rubrics", ~21:31 |
+| Planner stays high-level; granular planning cascades errors | § "Introducing the 'Planner' role", ~23:45 |
+| Generator/evaluator negotiate "done" on disk; grade the negotiated contract, not the spec | § "The generator-evaluator contract", ~24:56 |
+| 27 contract criteria; granular → agent fixes the exact line | § "Specificity in contracts…", ~32:04 |
+| Evaluator drives the app (plays the game) and catches behavioral bugs CI misses | ~30:33–31:18 |
+| Read the traces by hand as the primary debugging loop | ~33:26; Q&A ~1:01:25 |
+| Strip scaffolding as models improve; right for 4.5, frontier moved | § "Adjusting harnesses as models evolve", ~34:14 |
+| File system for shared state; models don't overwrite JSON | § "First long-running agent patterns", ~12:34; ~36:26 |
+| Verifier should NOT get the maker's reasoning trace | Q&A ~1:00:05 |
+| Git worktrees for parallel work | Q&A ~1:07:04 |
+| Hosted/long runs belong to the Agent SDK, not laptop Claude Code | Q&A ~57:10 |
+| This pattern is greenfield-biased; brownfield needs custom control | Q&A ~1:11:00 |
+| Models willingly throw everything away and restart | Q&A ~46:37 |

--- a/docs/specs/fable-loop-compounding/prd.md
+++ b/docs/specs/fable-loop-compounding/prd.md
@@ -20,6 +20,9 @@ Specflow should treat Fable-class models as high-capability workers and orchestr
 - `ROUTINE-01`: Specflow can scaffold `/loop`/routine manifests for cron, GitHub Actions, or hosted agent triggers while preserving the same run contract and stop rules.
 - `VISION-GATE-01`: Teardown/Gate D evidence supports screenshot plus vision-verifier findings, while the mechanical gate still validates evidence paths and value-bearing re-reads.
 - `COST-01`: Loop ledgers record provider/model, token/cost estimates when available, gate attempt counts, and cost-per-accepted-change counters.
+- `VERIFIER-02`: Feature-build adds a maker-verifier negotiation stage that writes a slice-specific verification contract before implementation and can run adversarial runtime verification against the built product.
+- `TRACE-01`: Specflow provides trace-review tooling over `ledger.jsonl`, transcripts, provider events, and gate results so operators can find where maker judgment diverged from verifier or mechanical gates.
+- `HARNESS-MINIMAL-01`: Model-routing and cost scaffolding stay thin, ledger-backed, and removable as provider capabilities improve; the trust boundary remains mechanical gates plus human-gated actions.
 
 ## Non-Goals
 
@@ -60,10 +63,16 @@ The prompt should say why the work matters and when to stop/check in, but it sho
 
 Portfolio-level routines may ask a planning provider to inspect important projects and propose improvements, but any proposed improvement must enter spec-build as a normal PRD/ticket packet before implementation.
 
+Specflow intentionally keeps durable spec-build artifacts as the outer contract for brownfield, auditable work. It does not respond to stronger models by pinning more implementation detail up front. Fine-grained "done means this, verified this way" criteria are negotiated inside feature-build between the maker and an independent verifier, then written to disk before implementation. The verifier may use Playwright, screenshots, console/network logs, or other runtime evidence to refute the built behavior, but its judgment remains evidence subordinate to mechanical gates.
+
+Harness scaffolding is disposable. Model names, effort tiers, cost estimates, and provider-specific routing knobs are policy metadata recorded in the ledger, not product doctrine. If a future provider makes a scaffold unnecessary, Specflow should preserve the gate and delete the scaffold rather than carry stale complexity.
+
 ## Success Criteria
 
-- Tickets declare executable journeys and surfaces for all seven requirements.
+- Tickets declare executable journeys and surfaces for all ten requirements.
 - Gate A falsification attacks overclaim, self-modifying skills, cost runaway, and weak verifier separation.
 - Gate B seam/ADR/journey checks pass against the local ticket packet.
 - Gate B.5 simulation covers long-running session, hosted routine, UI vision, and model fallback routes.
 - Resulting GitHub issues are ready for feature-build implementation.
+- Feature-build can produce and enforce a slice-local verification contract before maker work begins.
+- Operators can inspect a divergence report that links ledger events, transcripts, provider events, and failed gates.

--- a/docs/specs/fable-loop-compounding/run-contract.yaml
+++ b/docs/specs/fable-loop-compounding/run-contract.yaml
@@ -16,7 +16,8 @@ run_contract:
     - docs/specs/fable-loop-compounding/issues.json
     - docs/specs/fable-loop-compounding/simulation.md
     - docs/specs/fable-loop-compounding/specflow-audit.md
-  stop_condition: Stop at spec-build handoff; GitHub issues #83-#89 are created and ready for feature-build.
+    - docs/specs/fable-loop-compounding/long-running-agents-evaluation.md
+  stop_condition: Stop at spec-build handoff; GitHub issues #83-#89 and #92-#94 are created and ready for feature-build.
   never_without_human:
     - git push
     - open PR

--- a/docs/specs/fable-loop-compounding/simulation.md
+++ b/docs/specs/fable-loop-compounding/simulation.md
@@ -16,7 +16,11 @@
 - **Parallel implementer:** maker and verifier run in separate worktrees. Gap checked: Specflow must not auto-merge or push delegated work.
 - **UI reviewer:** screenshot plus vision finding enters Gate D. Gap checked: vision output is evidence only; teardown-gate remains the gate of record.
 - **Platform scheduler:** `/loop`, cron, GitHub, or hosted trigger runs the same `specflow run` command. Gap checked: scheduled routines do not bypass human gates.
+- **Feature-build maker:** proposes a slice-local verification contract before implementation. Gap checked: fine-grained HOW-verified criteria are negotiated inside feature-build, not front-loaded into spec-build.
+- **Runtime adversary:** drives the built product through Playwright/log/screenshot/value evidence. Gap checked: runtime verifier findings are evidence only and cannot replace journey/mechanical gates.
+- **Trace reviewer:** inspects a long-running loop after maker/verifier disagreement. Gap checked: transcript/provider summarization is opt-in; missing evidence is reported as missing.
+- **Maintainer:** reviews stale provider effort/model/cost scaffolding after models improve. Gap checked: durable trust fields remain in the ledger while transient knobs can be removed.
 
 ## Gate Result
 
-No CRITICAL design gap survives. Feature-build should implement the seven tickets as separate slices or a tightly staged epic.
+No CRITICAL design gap survives. Feature-build should implement the ten tickets as separate slices or a tightly staged epic, with #92/#93/#94 treated as the loop-talk adjustment layer before broad runtime automation.

--- a/docs/specs/fable-loop-compounding/specflow-audit.md
+++ b/docs/specs/fable-loop-compounding/specflow-audit.md
@@ -25,7 +25,22 @@
 | #87 | ROUTINE-01 |
 | #88 | VISION-GATE-01 |
 | #89 | COST-01 |
+| #92 | VERIFIER-02 |
+| #93 | TRACE-01 |
+| #94 | HARNESS-MINIMAL-01 |
+
+## Loop-Talk Adjustment Rerun
+
+**Date:** 2026-07-01
+**Reason:** The Anthropic long-running agents evaluation in `docs/specs/fable-loop-compounding/long-running-agents-evaluation.md` exposed three missing requirements: maker-verifier negotiation plus runtime verification, trace-review tooling, and minimal/removable provider scaffolding.
+
+| Check | Command | Result |
+|---|---|---|
+| Falsification | `node scripts/verify-falsification.cjs docs/specs/fable-loop-compounding/falsification.md --require-pass --binds-prd docs/specs/fable-loop-compounding/prd.md` | PASS: PRD hash binding refreshed after adding #92/#93/#94. |
+| Seam-lite | `node scripts/verify-seams.cjs docs/specs/fable-loop-compounding/tickets.json --repo-root .` | PASS: 8 seams across 10 tickets. |
+| ADR/reuse | `node scripts/verify-adr.cjs docs/specs/fable-loop-compounding/tickets.json --repo-root .` | PASS/SKIP: no ADR folder detected; reuse declared against existing runner/policy/status surfaces. |
+| Ticket-journey join | `node scripts/verify-ticket-journey.cjs docs/specs/fable-loop-compounding --issues docs/specs/fable-loop-compounding/issues.json` | PASS: 10 journeys, 10 issues. |
 
 ## Handoff
 
-The ticket packet has been created as GitHub issues and is ready to run through feature-build slices.
+The ticket packet has been created as GitHub issues and is ready to run through feature-build slices. The loop-talk delta keeps spec-build as the outer WHAT contract and moves slice-local HOW-verified detail into feature-build maker-verifier negotiation.

--- a/docs/specs/fable-loop-compounding/tickets.json
+++ b/docs/specs/fable-loop-compounding/tickets.json
@@ -61,5 +61,32 @@
     "adrNone": "This repository has no ADR directory; reuse is declared against existing ledger, adapter parsing, and status output.",
     "reuses": ["scripts/specflow-runner.cjs", "bin/specflow.js", "tests/contracts/loop-run-contract.test.js"],
     "journeys": ["J-FABLE-COST-ACCOUNTING"]
+  },
+  {
+    "id": "VERIFIER-02",
+    "title": "Add maker-verifier negotiation and adversarial runtime verification",
+    "writes": ["run_contract", "ledger.jsonl", "runAdapter", "verifier"],
+    "reads": ["adapter_policy", "output_path", "transcript_path", "journey tests", "teardown-gate"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing verifier, adapter, journey, and teardown evidence surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "scripts/teardown-gate.cjs", "templates/QA/loops/feature-build.yaml", "tests/contracts/loop-run-contract.test.js"],
+    "journeys": ["J-FABLE-VERIFIER-NEGOTIATION"]
+  },
+  {
+    "id": "TRACE-01",
+    "title": "Add specflow run trace divergence report for long-running loops",
+    "writes": ["runStatus", "ledger.jsonl"],
+    "reads": ["ledger.jsonl", "run_contract", "transcript_path", "parseProviderEvents", "verifier", "gate_c"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing ledger, status, and CLI surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "bin/specflow.js", "tests/contracts/loop-run-contract.test.js"],
+    "journeys": ["J-FABLE-TRACE-REVIEW"]
+  },
+  {
+    "id": "HARNESS-MINIMAL-01",
+    "title": "Keep model scaffolding thin and removable as providers improve",
+    "writes": ["adapter_policy", "runStatus", "docs"],
+    "reads": ["adapter_policy", "ledger.jsonl", "runAdapter", "gate_c"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing adapter policy, status, and documentation surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "templates/adapter-policies/claude-print.safe.yml", "templates/adapter-policies/codex-exec.safe.yml", "README.md"],
+    "journeys": ["J-FABLE-HARNESS-MINIMAL"]
   }
 ]

--- a/docs/specs/fable-loop-compounding/tickets.md
+++ b/docs/specs/fable-loop-compounding/tickets.md
@@ -84,3 +84,37 @@ Acceptance:
 - `specflow run status` summarizes attempts, accepted gates, rejected gates, and cost per accepted gate/change.
 - Missing usage metadata is recorded as unknown, not fabricated.
 - Plan entitlement metadata is recorded as policy context, not treated as zero cost unless the provider explicitly reports zero billable usage.
+
+### #92 VERIFIER-02 - Add maker-verifier negotiation and adversarial runtime verification
+
+**Journey:** `J-FABLE-VERIFIER-NEGOTIATION`
+
+Acceptance:
+- Feature-build can insert a pre-implementation negotiation stage where the maker proposes a slice-local verification contract and the independent verifier can reject it as too vague, too broad, or missing edge/runtime checks.
+- The accepted verification contract is written to disk under the run directory before maker implementation starts and is referenced by later ledger entries.
+- The verifier input remains artifact plus rubric/contract, not maker reasoning trace.
+- Verifier policies can declare an adversarial runtime verifier that drives the built product through Playwright or equivalent tooling, including screenshots, console logs, network failures, and value re-reads when applicable.
+- Runtime verifier rubrics support weighted criteria and default to a refute/harsh posture when evidence is incomplete.
+- A runtime verifier verdict is evidence only; gate advance remains blocked until the owning mechanical gate or journey test passes.
+
+### #93 TRACE-01 - Add `specflow run trace` divergence report for long-running loops
+
+**Journey:** `J-FABLE-TRACE-REVIEW`
+
+Acceptance:
+- CLI exposes `specflow run trace <run-dir>` or equivalent, reading `ledger.jsonl`, run contract, transcript paths, provider events, verifier entries, and gate results.
+- Trace output groups each stage attempt by maker action, verifier response, mechanical gate result, human gate stop, and final disposition.
+- The report highlights divergence: maker claimed done but verifier failed, verifier passed but mechanical gate failed, provider refused/fell back, human-gated action was attempted, or transcript/evidence is missing.
+- The command never sends transcripts to a provider by default; provider summarization is opt-in and recorded in the ledger.
+- Missing transcript paths, dangling evidence refs, and unknown model/cost fields are reported as unknown or missing, not inferred.
+
+### #94 HARNESS-MINIMAL-01 - Keep model scaffolding thin and removable as providers improve
+
+**Journey:** `J-FABLE-HARNESS-MINIMAL`
+
+Acceptance:
+- PRD/docs state that Specflow preserves mechanical gates and human-gated stop rules, but provider-specific scaffolding should be removed when it stops paying for itself.
+- Adapter policy validation distinguishes durable trust fields (`requested_model`, `effective_model`, role, fallback/refusal, budget) from transient provider knobs such as effort names or model-family marketing labels.
+- Cost/status output can show when a policy field is unused, unsupported, or always unknown so stale scaffolding is visible.
+- No gate may depend solely on a provider-specific effort tier, model brand, or cost estimate.
+- Documentation positions Specflow as a brownfield/auditable loop control plane, not a free-running demo harness.

--- a/docs/specs/fable-loop-compounding/verdict.md
+++ b/docs/specs/fable-loop-compounding/verdict.md
@@ -7,7 +7,7 @@
 
 ## Why This Ships
 
-The PRD does not ask Specflow to trust a stronger model. It asks Specflow to add the control-plane surfaces stronger models need: effort-aware model routing, durable state plus lesson files, independent verification, isolated execution, `/loop`/scheduled routines, vision evidence, and cost accounting. Each ticket preserves mechanical gates and human stop rules.
+The PRD does not ask Specflow to trust a stronger model. It asks Specflow to add the control-plane surfaces stronger models need: effort-aware model routing, durable state plus lesson files, independent verification, maker-verifier negotiation, runtime verification, isolated execution, `/loop`/scheduled routines, vision evidence, trace review, harness-minimality, and cost accounting. Each ticket preserves mechanical gates and human stop rules.
 
 ## Stipulations
 
@@ -16,3 +16,6 @@ The PRD does not ask Specflow to trust a stronger model. It asks Specflow to add
 - Do not require Anthropic-only infrastructure for core Specflow loops.
 - Do not fabricate token/cost fields when provider metadata is missing.
 - Keep `never_without_human` gates unchanged for push, PR creation, merge, `--no-verify`, and contract overrides.
+- Do not move granular implementation detail into spec-build merely because the provider model is stronger; feature-build owns slice-local HOW-verified contracts.
+- Do not send transcripts to a provider by default in trace tooling.
+- Do not let provider effort labels, model brands, or cost estimates become gate criteria.


### PR DESCRIPTION
## Summary

Adds the concrete Specflow ticket adjustments derived from `docs/specs/fable-loop-compounding/long-running-agents-evaluation.md`:

- #92 `VERIFIER-02`: maker-verifier negotiation plus adversarial runtime verification.
- #93 `TRACE-01`: `specflow run trace` divergence report for long-running loops.
- #94 `HARNESS-MINIMAL-01`: keep provider/model scaffolding thin, ledger-backed, and removable.

The evaluation is now stored under the fable-loop-compounding spec folder. The raw transcript was intentionally removed from the PR; the repo keeps the analysis and timestamped talk references, not a copied transcript of uncertain provenance.

## Spec-build rerun

- Updated PRD requirements from seven to ten.
- Refreshed Gate A falsification hash binding after the PRD changed.
- Added adversary coverage for:
  - over-prescriptive spec-build detail,
  - runtime-verifier self-attestation,
  - trace tooling leaking or summarizing transcripts by default,
  - stale provider/model scaffolding becoming doctrine.
- Updated Gate B audit, B.5 simulation, run contract, issue packet, and hops for #92/#93/#94.

## Verification

- `node scripts/verify-falsification.cjs docs/specs/fable-loop-compounding/falsification.md --require-pass --binds-prd docs/specs/fable-loop-compounding/prd.md`
- `node scripts/verify-ticket-journey.cjs docs/specs/fable-loop-compounding --issues docs/specs/fable-loop-compounding/issues.json`
- `node scripts/verify-seams.cjs docs/specs/fable-loop-compounding/tickets.json --repo-root .`
- `node scripts/verify-adr.cjs docs/specs/fable-loop-compounding/tickets.json --repo-root .`
- `git diff --check -- docs/specs/fable-loop-compounding`
