### PR TITLE
feat: verifier runtime lifecycle — epic #100 (VERIFIER-CONTRACT/POLICY/RUNTIME/TRACE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ npm-debug.log*
 tmp/
 temp/
 
+# Agent/generated local state
+.claude-flow/
+.swarm/
+**/.claude-flow/
+**/.swarm/
+
 # Node modules
 node_modules/
 sample_spec/node_modules

--- a/docs/specs/verifier-runtime-lifecycle/adversary-review.md
+++ b/docs/specs/verifier-runtime-lifecycle/adversary-review.md
@@ -1,0 +1,29 @@
+# Verifier Runtime Lifecycle - Adversary Review
+
+**Date:** 2026-07-02
+**Loop:** spec-build
+**Source:** #100, #84, #92, `docs/specs/fable-loop-compounding/`
+**Verdict:** SHIP_WITH_STIPULATIONS
+
+## Findings
+
+| Severity | Finding | Disposition |
+|---|---|---|
+| FATAL | If implemented as another reviewer prompt, this epic worsens the self-grading problem instead of fixing it. | Closed by requiring durable verifier contracts, separate verifier context, runtime evidence, and mechanical gate reruns. |
+| SERIOUS | Verifier approval could be confused with gate pass. | Closed by `I-VERIFIER-001`: verifier output is evidence only; owning script/journey gate decides. |
+| SERIOUS | Feeding maker reasoning trace to the verifier can launder the maker's delusion into the verifier context. | Closed by `I-VERIFIER-002`: verifier receives artifact/spec/rubric/runtime surface, not maker trace by default. |
+| SERIOUS | Static contract checks alone will miss plausible UI/backend bugs from long-running agents. | Closed by `VERIFIER-RUNTIME-01`: runtime evidence path for UI/workflow changes. |
+| SERIOUS | Trace output could summarize away the divergence operators need to inspect. | Closed by `VERIFIER-TRACE-01`: ledger must preserve maker claim, verifier finding, gate result, and evidence paths. |
+| P1 | Vision evidence might be treated as proof of value-bearing behavior. | Closed by requiring value rereads/API/backend assertions when state matters. |
+| P2 | This could overfit to Fable branding. | Closed by model-agnostic policy language; provider/model/effort fields are metadata only. |
+
+## Required Stipulations
+
+- Gate advance must remain impossible from provider output, verifier prose, model confidence, or provider exit code alone.
+- Runtime verifier evidence must be executable where the slice has UI/workflow behavior.
+- The verifier must not inherit maker reasoning trace unless a human explicitly approves the exception.
+- #93 trace work must consume the ledger shape produced here.
+
+## Gate A Result
+
+SHIP_WITH_STIPULATIONS. The PRD is suitable for ticketing because the trust boundary is explicit and the implementation can be sliced into mechanical runtime surfaces.

--- a/docs/specs/verifier-runtime-lifecycle/contract.yml
+++ b/docs/specs/verifier-runtime-lifecycle/contract.yml
@@ -1,0 +1,76 @@
+feature: verifier-runtime-lifecycle
+requirements:
+  - id: REQ-VERIFIER-CONTRACT-01
+    statement: Feature-build persists a maker verification proposal and accepted verifier contract before implementation.
+  - id: REQ-VERIFIER-POLICY-01
+    statement: Verifier policy runs separately from maker policy and excludes maker reasoning trace by default.
+  - id: REQ-VERIFIER-RUNTIME-01
+    statement: UI/workflow slices collect executable runtime evidence and value-bearing rereads where applicable.
+  - id: REQ-VERIFIER-TRACE-01
+    statement: Ledger/status/trace records maker claim, verifier finding, mechanical gate result, and divergence.
+journeys:
+  - journey_meta:
+      id: J-VERIFIER-CONTRACT-LIFECYCLE
+      persona: feature_builder
+      owner_ticket: VERIFIER-CONTRACT-01
+      assertion_bar: accepted verification contract exists before maker implementation starts
+    scenario: negotiate and persist the slice-local verification contract
+    given:
+      - a feature-build run has an outer ticket contract and journey IDs
+      - maker and verifier policies are declared
+    when:
+      - the maker writes a verification proposal
+      - the verifier accepts or rejects it
+    then:
+      - accepted proposals write `.specflow/runs/<slug>/verification-contract.json`
+      - rejected proposals block maker implementation with a verifier finding
+      - the ledger records the proposal path, verifier decision, and accepted contract path
+
+  - journey_meta:
+      id: J-VERIFIER-POLICY-ISOLATION
+      persona: independent_verifier
+      owner_ticket: VERIFIER-POLICY-01
+      assertion_bar: verifier ledger entry has separate policy, transcript, and output references
+    scenario: run verifier from artifact/spec/rubric without maker trace contamination
+    given:
+      - a maker artifact exists under the run directory
+      - a verifier policy is configured
+    when:
+      - the verifier stage runs
+    then:
+      - verifier input includes artifact, spec, rubric, and accepted verification contract
+      - verifier input does not include maker reasoning transcript unless a human exception is recorded
+      - verifier output is stored separately from maker output
+
+  - journey_meta:
+      id: J-VERIFIER-RUNTIME-EVIDENCE
+      persona: runtime_adversary
+      owner_ticket: VERIFIER-RUNTIME-01
+      assertion_bar: runtime findings include executable evidence and value rereads where state matters
+    scenario: attack a built UI/workflow slice with runtime checks
+    given:
+      - a slice declares UI or workflow behavior
+      - an accepted verification contract names runtime checks
+    when:
+      - the verifier runs the runtime evidence commands
+    then:
+      - Playwright/browser evidence is persisted when configured
+      - console and network findings are captured when available
+      - value-bearing behavior is reread through API, DB, or custom script evidence
+      - missing executable surface creates a blocked verifier finding instead of invented evidence
+
+  - journey_meta:
+      id: J-VERIFIER-TRACE-DIVERGENCE
+      persona: loop_operator
+      owner_ticket: VERIFIER-TRACE-01
+      assertion_bar: status or trace output separates maker claim, verifier result, and gate result
+    scenario: inspect divergence after a long-running verifier disagreement
+    given:
+      - a run ledger contains maker, verifier, and gate entries
+    when:
+      - the operator runs status or trace review
+    then:
+      - maker claim is shown separately from verifier finding
+      - verifier finding is shown separately from mechanical gate result
+      - missing transcript or evidence refs are reported as missing
+      - no transcript content is sent to a provider by default

--- a/docs/specs/verifier-runtime-lifecycle/falsification.md
+++ b/docs/specs/verifier-runtime-lifecycle/falsification.md
@@ -1,0 +1,71 @@
+# Verifier Runtime Lifecycle - Falsification
+
+**Date:** 2026-07-02
+**Reviewed PRD:** `docs/specs/verifier-runtime-lifecycle/prd.md`
+PRD SHA-256: 18da98bac8d66590eb662f74f54d8f6c3c7f5d3780a46aa1fc9430810955e7a7
+
+## Premise Attack
+
+| Claim | Attack | Result |
+|---|---|---|
+| A verifier lifecycle improves trust for frontier agents. | A verifier can still be another model and can still be fooled. | Holds only because verifier output is not the gate; mechanical gates remain decisive. |
+| Runtime verification is necessary. | Static tests may be enough for non-UI CLI slices. | Holds with scope: runtime verification is required for UI/workflow surfaces and optional/custom for pure CLI slices. |
+| Maker proposal before implementation improves outcomes. | Maker could propose weak checks that approve its intended approach. | Holds only because verifier can reject the proposal before implementation. |
+
+## Claim Inventory
+
+| Claim | Source | Verification route |
+|---|---|---|
+| Provider output must not advance gates. | Existing adapter/genuine-looper docs and #100 | Encode invariant and ledger gate result separately. |
+| Verifier must not consume maker reasoning trace by default. | #100 and long-running agent evaluation | Add verifier policy/input contract and tests. |
+| Runtime evidence should include Playwright/console/network/rereads where applicable. | #100 and docs/ss evaluation | Add runtime evidence artifact schema and smoke tests. |
+| Trace must show maker/verifier/gate divergence. | #93 and #100 | Add ledger fields consumed by trace/status output. |
+
+## Dependency Audit
+
+| Dependency | Risk | Disposition |
+|---|---|---|
+| `scripts/specflow-runner.cjs` | Existing runner may not have verifier lifecycle primitives. | Ticket VERIFIER-CONTRACT-01 owns additions. |
+| Adapter policy templates | Maker/verifier policy split can be underspecified. | Ticket VERIFIER-POLICY-01 owns schema and validation. |
+| Playwright/runtime tools | Not every project has a running app. | Verifier can block with missing executable surface rather than invent evidence. |
+| `ledger.jsonl` | Divergence can be lost if maker/verifier/gate are a single event. | Ticket VERIFIER-TRACE-01 owns event separation. |
+
+## Acceptance Gate Attack
+
+| Acceptance | Attack | Required guard |
+|---|---|---|
+| Persist verification contract. | Persisted but not enforced. | Gate/stage must read contract before maker implementation. |
+| Separate verifier context. | Verifier gets maker transcript as convenience. | Default must forbid maker reasoning trace. |
+| Runtime evidence path. | Screenshot-only proof passes. | Value-bearing state requires reread/API/DB/custom assertion. |
+| Trace divergence. | Summary hides failed evidence. | Trace must link raw evidence paths and missing refs. |
+
+## Source / Reality Ledger
+
+| Source claim | Reality check | Status |
+|---|---|---|
+| Repo has `specflow run` and ledger surfaces. | `bin/specflow.js` and `scripts/specflow-runner.cjs` expose loop runtime surfaces. | PASS |
+| Repo has Playwright journey concept. | Docs and compiler mention Playwright journey tests. | PASS |
+| Repo has Gate D/teardown evidence model. | `scripts/teardown-gate.cjs` exists and validates evidence paths. | PASS |
+| Repo already has full verifier lifecycle. | Only partial verifier references exist. | GAP OWNED |
+
+## Overclaim / Scope Leakage
+
+| Overclaim | Correction | Owner |
+|---|---|---|
+| "Independent verifier solves trust." | Verifier is evidence; mechanical gate decides. | VERIFIER-POLICY-01 |
+| "Vision proves UI correctness." | Vision supports evidence; journey/value rereads prove behavior. | VERIFIER-RUNTIME-01 |
+| "This makes Specflow an orchestrator." | Specflow remains a harness for one contracted lane. | PRD non-goal |
+
+## Banned-Mode Self-Check
+
+| Banned mode | Present? | Evidence |
+|---|---|---|
+| Self-grading accepted as pass | No | Invariant forbids provider/verifier output as gate. |
+| Decorative YAML only | No | Tickets require runner, ledger, schema, tests. |
+| Hidden model downgrade/fallback | No | Model fields are inherited from #83/#89 and preserved as metadata. |
+| Runtime verification optional for UI/workflow | No | Required by VERIFIER-RUNTIME-01. |
+| Human gates bypassed | No | No push/merge/override automation in scope. |
+
+## Final Verdict
+
+PASS WITH STIPULATIONS. The PRD is valid if implementation preserves the authority split: maker proposes, verifier attacks, mechanical gate decides, ledger remembers.

--- a/docs/specs/verifier-runtime-lifecycle/hops.md
+++ b/docs/specs/verifier-runtime-lifecycle/hops.md
@@ -1,0 +1,25 @@
+# Verifier Runtime Lifecycle - Hops
+
+**Date:** 2026-07-02
+**Purpose:** Pre-commit the integration oracle consumed by feature-build and Gate D.
+
+## Persona Hops
+
+| Journey | Persona | From | Required control | Expected value / reread | Oracle/source |
+|---|---|---|---|---|---|
+| J-VERIFIER-CONTRACT-LIFECYCLE | feature builder | accepted ticket contract | maker verification proposal | `verification-contract.json` exists before maker implementation starts | `.specflow/runs/<slug>/verification-contract.json` |
+| J-VERIFIER-POLICY-ISOLATION | independent verifier | maker output artifact | verifier policy input | verifier input references artifact/spec/rubric and does not reference maker reasoning transcript | verifier ledger entry |
+| J-VERIFIER-RUNTIME-EVIDENCE | runtime adversary | built UI/workflow slice | runtime verifier command | Playwright/API/log/reread evidence paths exist and missing executable surface blocks the run | `verifier-findings.jsonl` |
+| J-VERIFIER-TRACE-DIVERGENCE | loop operator | run directory | trace/status command | maker claim, verifier result, mechanical gate result, and divergence are shown as separate fields | `ledger.jsonl` and trace output |
+
+## Seam-Derived Hops
+
+Derived by `node scripts/verify-seams.cjs docs/specs/verifier-runtime-lifecycle/tickets.json --repo-root .`.
+
+| Seam surface | Pair / owner set | Kind | Required re-read assertion |
+|---|---|---|---|
+| `ledger.jsonl` | VERIFIER-CONTRACT-01, VERIFIER-POLICY-01, VERIFIER-RUNTIME-01, VERIFIER-TRACE-01 | writer-writer | A run with all verifier lifecycle stages re-reads ledger entries in order and preserves distinct maker proposal, verifier decision, runtime finding, and gate result events. |
+| `output_path` | VERIFIER-POLICY-01 -> VERIFIER-RUNTIME-01 / VERIFIER-TRACE-01 | writer-reader | Verifier/runtime/trace consumers read the same output path written by the verifier policy stage, with missing refs reported as missing. |
+| `run_contract` | VERIFIER-CONTRACT-01 -> VERIFIER-TRACE-01 | writer-reader | Trace/status re-read the accepted verification contract reference from the run contract or ledger before displaying divergence. |
+| `runAdapter` | VERIFIER-POLICY-01 -> VERIFIER-CONTRACT-01 | writer-reader | Verifier policy execution uses the same adapter runner surface that contract negotiation validates. |
+| `transcript_path` | VERIFIER-POLICY-01 -> VERIFIER-TRACE-01 | writer-reader | Trace/status show verifier transcript references as separate from maker transcript references without sending transcript content to a provider by default. |

--- a/docs/specs/verifier-runtime-lifecycle/issues.json
+++ b/docs/specs/verifier-runtime-lifecycle/issues.json
@@ -1,0 +1,7 @@
+[
+  {
+    "number": 100,
+    "title": "[SPECFLOW] VERIFIER-EPIC: runtime verifier contract lifecycle for frontier agents",
+    "body": "Journey IDs: J-VERIFIER-CONTRACT-LIFECYCLE, J-VERIFIER-POLICY-ISOLATION, J-VERIFIER-RUNTIME-EVIDENCE, J-VERIFIER-TRACE-DIVERGENCE\n\nLocal child tickets: VERIFIER-CONTRACT-01, VERIFIER-POLICY-01, VERIFIER-RUNTIME-01, VERIFIER-TRACE-01.\n\nSee docs/specs/verifier-runtime-lifecycle/tickets.md for the spec-built packet."
+  }
+]

--- a/docs/specs/verifier-runtime-lifecycle/prd.md
+++ b/docs/specs/verifier-runtime-lifecycle/prd.md
@@ -1,0 +1,60 @@
+# Verifier Runtime Lifecycle PRD
+
+**Date:** 2026-07-02
+**Loop:** spec-build
+**Slug:** `verifier-runtime-lifecycle`
+**Source issue:** #100
+**Goal:** Make frontier-agent verification a first-class Specflow lifecycle, not a reviewer prompt.
+
+## Problem
+
+Fable-class and other frontier coding agents can now run longer, produce larger changes, and explain those changes with high confidence. That increases Specflow's value, but it also makes a weak harness dangerous. A powerful maker can become planner, implementer, summarizer, reviewer, and judge unless the runtime keeps those authorities separate.
+
+The existing Fable packet already names independent verification (#84) and maker-verifier negotiation (#92). Issue #100 sharpens those into a lifecycle: the maker proposes how the slice should be verified, an independent verifier accepts or rejects that proposal, the maker implements, the verifier attacks the built artifact with runtime evidence where applicable, and a mechanical gate decides whether the run advances.
+
+## Positioning
+
+Specflow is the trust harness for frontier coding agents. It lets Fable, Claude Code, Codex, Ruflo, or any other worker produce the work, but only contracts, gates, and evidence decide what ships.
+
+The model is the actuator. The gate is the sensor. Provider output, provider confidence, verifier prose, and provider exit codes are never gate verdicts.
+
+## Requirements
+
+- `VERIFIER-CONTRACT-01`: Persist a slice-local verification proposal and accepted verification contract before maker implementation starts.
+- `VERIFIER-POLICY-01`: Run verifier policy separately from maker policy, with artifact/spec/rubric input and no maker reasoning trace by default.
+- `VERIFIER-RUNTIME-01`: Collect adversarial runtime evidence for UI/workflow changes, including Playwright/browser execution, console or network signals, and value-bearing API/backend rereads where applicable.
+- `VERIFIER-TRACE-01`: Record maker claim, verifier finding, mechanical gate result, and divergence in ledger/status/trace output.
+
+## Non-Goals
+
+- Making Specflow a swarm orchestrator.
+- Trusting Fable, Claude, Codex, Oracle, or any model as a gate.
+- Requiring vision for every verifier run.
+- Adding cron, hosted routines, or background scheduling.
+- Over-specifying implementation details that should be negotiated inside feature-build.
+
+## Operating Model
+
+```text
+outer ticket contract
+  -> maker verification proposal
+  -> independent verifier accepts/rejects
+  -> accepted verification contract on disk
+  -> maker implementation
+  -> verifier runtime findings
+  -> mechanical gate rerun
+  -> ledgered disposition
+```
+
+The verifier sees artifacts, app behavior, spec, and rubric. The verifier does not inherit maker reasoning trace unless a human explicitly approves that exception and the ledger records it.
+
+Runtime verification is required when a change can pass static checks while failing in the app. For UI and workflow slices, a screenshot alone is weak evidence. The verifier must pair visual evidence with at least one executable assertion or reread when the slice has value-bearing state.
+
+## Success Criteria
+
+- Feature-build can create and persist `verification-proposal.md` and `verification-contract.json` under `.specflow/runs/<slug>/`.
+- A verifier can reject a proposal that lacks runtime checks, value rereads, or negative paths.
+- Verifier output is separate from maker output and ledgered separately.
+- Runtime verifier evidence can include Playwright steps, console logs, network logs, screenshot refs, API rereads, DB rereads, or custom script results.
+- Gate advance is impossible from verifier approval alone.
+- Operators can inspect maker claim vs verifier finding vs gate result without reading the whole transcript first.

--- a/docs/specs/verifier-runtime-lifecycle/run-contract.yaml
+++ b/docs/specs/verifier-runtime-lifecycle/run-contract.yaml
@@ -1,0 +1,27 @@
+run_contract:
+  loop: spec-build
+  goal: Create audited verifier lifecycle tickets from #100.
+  input_artifact: issue #100 plus #84/#92 and docs/specs/fable-loop-compounding
+  path: templates/QA/loops/spec-build.yaml
+  current_stage_or_rail: handoff
+  next_gate: feature-build local tickets in order; start with VERIFIER-CONTRACT-01 and VERIFIER-POLICY-01
+  durable_evidence:
+    - docs/specs/verifier-runtime-lifecycle/prd.md
+    - docs/specs/verifier-runtime-lifecycle/adversary-review.md
+    - docs/specs/verifier-runtime-lifecycle/falsification.md
+    - docs/specs/verifier-runtime-lifecycle/verdict.md
+    - docs/specs/verifier-runtime-lifecycle/hops.md
+    - docs/specs/verifier-runtime-lifecycle/contract.yml
+    - docs/specs/verifier-runtime-lifecycle/tickets.md
+    - docs/specs/verifier-runtime-lifecycle/tickets.json
+    - docs/specs/verifier-runtime-lifecycle/issues.json
+    - docs/specs/verifier-runtime-lifecycle/specflow-audit.md
+    - docs/specs/verifier-runtime-lifecycle/simulation.md
+  stop_condition: Stop at spec-build handoff; do not implement until feature-build consumes the local ticket packet.
+  never_without_human:
+    - git push
+    - open PR
+    - merge
+    - --no-verify
+    - override contract
+  terminal_status: handoff

--- a/docs/specs/verifier-runtime-lifecycle/simulation.md
+++ b/docs/specs/verifier-runtime-lifecycle/simulation.md
@@ -1,0 +1,38 @@
+# Verifier Runtime Lifecycle - Gate B.5 Simulation
+
+**Date:** 2026-07-02
+**Loop:** spec-build
+**Stage:** GATE_B5
+**Input artifacts:** `prd.md`, `contract.yml`, `tickets.md`, `hops.md`
+**Status:** PASS. No CRITICAL ticketization gap survives.
+
+## Persona Routes
+
+- **Feature-build maker:** starts from #100 and tries to implement immediately. The ticket packet blocks this by requiring `verification-proposal.md` and accepted `verification-contract.json` before maker implementation.
+- **Independent verifier:** receives maker output and asks for the maker reasoning transcript. The policy ticket blocks trace contamination by default and requires a human-recorded exception for any trace inclusion.
+- **Runtime adversary:** tests a UI/workflow change that looks visually complete but has dead backend state. VERIFIER-RUNTIME-01 requires executable runtime evidence plus API/DB/custom reread when value-bearing state matters.
+- **CLI-only implementer:** works on a pure runner/status slice with no app surface. The simulation checks that runtime evidence is not over-required; custom script or mechanical gate evidence is acceptable.
+- **Missing-surface verifier:** cannot launch an app or find a runnable journey. The required behavior is a blocked verifier finding naming the missing executable surface, not fabricated evidence.
+- **Trace reviewer:** investigates a long run where maker says done, verifier says pass, but the mechanical gate fails. VERIFIER-TRACE-01 requires maker claim, verifier finding, and gate result to be displayed as separate fields.
+- **Vision-heavy reviewer:** inspects a screenshot and wants to approve. The packet keeps screenshot/vision evidence subordinate to runtime/value rereads and the owning gate.
+- **Frontier-model planner:** tries to use Fable/Claude/Codex model quality as a gate. The invariants and ticket packet treat model/provider/effort as metadata only.
+
+## Findings
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| Runtime verifier could be impossible in projects without a running app. | P1 if omitted | Covered by VERIFIER-RUNTIME-01: emit a blocked finding naming missing executable surface or use custom-script/mechanical evidence for non-UI slices. |
+| Verifier could inherit maker trace for convenience. | CRITICAL if permitted by default | Covered by VERIFIER-POLICY-01 and I-VERIFIER-002. |
+| Trace could flatten maker/verifier/gate into one summary. | P1 if omitted | Covered by VERIFIER-TRACE-01. |
+| Accepted verification contract could be written but not read by later stages. | P1 if omitted | Covered by seam-derived hops for `run_contract`, `ledger.jsonl`, and `output_path`. |
+
+## Gate Result
+
+GATE_B5 passes. Feature-build should implement the four local tickets in order:
+
+1. VERIFIER-CONTRACT-01
+2. VERIFIER-POLICY-01
+3. VERIFIER-RUNTIME-01
+4. VERIFIER-TRACE-01
+
+The first feature-build slice should stop after contract lifecycle and ledger separation are mechanically tested. Runtime Playwright evidence can be the second slice.

--- a/docs/specs/verifier-runtime-lifecycle/specflow-audit.md
+++ b/docs/specs/verifier-runtime-lifecycle/specflow-audit.md
@@ -1,0 +1,38 @@
+# Verifier Runtime Lifecycle - Gate B Audit
+
+**Date:** 2026-07-02
+**Loop:** spec-build
+**Stage:** GATE_B
+**Status:** PASS for the local ticket packet.
+
+## Required Checks
+
+| Check | Command | Result |
+|---|---|---|
+| Falsification | `node scripts/verify-falsification.cjs docs/specs/verifier-runtime-lifecycle/falsification.md --require-pass --binds-prd docs/specs/verifier-runtime-lifecycle/prd.md` | PASS: PRD hash matches. |
+| Seam-lite | `node scripts/verify-seams.cjs docs/specs/verifier-runtime-lifecycle/tickets.json --repo-root .` | PASS: 5 seams across 4 tickets. |
+| ADR/reuse | `node scripts/verify-adr.cjs docs/specs/verifier-runtime-lifecycle/tickets.json --repo-root .` | PASS/SKIP: no ADR folder detected; reuse is declared against existing runner, adapter, journey, and status surfaces. |
+| Ticket-journey join | `node scripts/verify-ticket-journey.cjs docs/specs/verifier-runtime-lifecycle --issues docs/specs/verifier-runtime-lifecycle/issues.json` | PASS: 4 journeys, 1 parent issue; every journey has a ticket reference and every ticket ref resolves. |
+
+## Ticket Map
+
+| Local ticket | Journey | Contract surface |
+|---|---|---|
+| VERIFIER-CONTRACT-01 | `J-VERIFIER-CONTRACT-LIFECYCLE` | verification proposal, accepted verification contract, run contract, ledger. |
+| VERIFIER-POLICY-01 | `J-VERIFIER-POLICY-ISOLATION` | maker/verifier policy split, transcript/output separation, adapter runner. |
+| VERIFIER-RUNTIME-01 | `J-VERIFIER-RUNTIME-EVIDENCE` | Playwright/runtime evidence, console/network capture, value rereads, blocked missing surface. |
+| VERIFIER-TRACE-01 | `J-VERIFIER-TRACE-DIVERGENCE` | status/trace display of maker claim, verifier result, gate result, evidence refs. |
+
+## Seam Results
+
+| Surface | Kind | Disposition |
+|---|---|---|
+| `ledger.jsonl` | writer-writer | Appended to hops as ordered lifecycle reread assertion. |
+| `output_path` | writer-reader | Appended to hops as verifier output consumer assertion. |
+| `run_contract` | writer-reader | Appended to hops as accepted-contract trace assertion. |
+| `runAdapter` | writer-reader | Appended to hops as shared adapter runner assertion. |
+| `transcript_path` | writer-reader | Appended to hops as separate verifier transcript assertion. |
+
+## Gate Result
+
+GATE_B passes. The ticket packet is ready for mandatory GATE_B5 simulation before feature-build handoff.

--- a/docs/specs/verifier-runtime-lifecycle/tickets.json
+++ b/docs/specs/verifier-runtime-lifecycle/tickets.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "VERIFIER-CONTRACT-01",
+    "title": "Persist verification proposal and accepted contract before implementation",
+    "writes": ["verification", "ledger.jsonl", "run_contract"],
+    "reads": ["adapter_policy", "runAdapter", "ledger.jsonl"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing runner, adapter policy, and ledger surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "templates/QA/loops/feature-build.yaml", "tests/contracts/loop-run-contract.test.js"],
+    "journeys": ["J-VERIFIER-CONTRACT-LIFECYCLE"]
+  },
+  {
+    "id": "VERIFIER-POLICY-01",
+    "title": "Run verifier policy in isolated artifact/spec/rubric context",
+    "writes": ["runAdapter", "transcript_path", "output_path", "ledger.jsonl"],
+    "reads": ["adapter_policy", "runAdapter", "transcript_path", "output_path"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing adapter execution and transcript/output policy surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "templates/adapter-policies/claude-print.safe.yml", "templates/adapter-policies/codex-exec.safe.yml"],
+    "journeys": ["J-VERIFIER-POLICY-ISOLATION"]
+  },
+  {
+    "id": "VERIFIER-RUNTIME-01",
+    "title": "Collect adversarial runtime evidence for UI/workflow slices",
+    "writes": ["Playwright", "console", "network", "teardown-gate", "ledger.jsonl"],
+    "reads": ["Playwright", "console", "network", "teardown-gate", "output_path"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against journey verification docs, Playwright compiler output, and teardown evidence checks.",
+    "reuses": ["scripts/specflow-compile.cjs", "scripts/teardown-gate.cjs", "docs/JOURNEY-VERIFICATION-HOOKS.md"],
+    "journeys": ["J-VERIFIER-RUNTIME-EVIDENCE"]
+  },
+  {
+    "id": "VERIFIER-TRACE-01",
+    "title": "Show maker claim, verifier finding, gate result, and divergence",
+    "writes": ["runStatus", "ledger.jsonl", "specflow run status"],
+    "reads": ["ledger.jsonl", "run_contract", "transcript_path", "output_path", "runStatus"],
+    "adrNone": "This repository has no ADR directory; reuse is declared against existing status, ledger, and CLI surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "bin/specflow.js", "tests/contracts/loop-run-contract.test.js"],
+    "journeys": ["J-VERIFIER-TRACE-DIVERGENCE"]
+  }
+]

--- a/docs/specs/verifier-runtime-lifecycle/tickets.md
+++ b/docs/specs/verifier-runtime-lifecycle/tickets.md
@@ -1,0 +1,63 @@
+# Verifier Runtime Lifecycle Ticket Packet
+
+**Source epic:** #100
+**Amends:** #84, #92
+**Loop:** spec-build
+
+## Scope
+
+These tickets turn the verifier epic into feature-buildable slices. The trust boundary is non-negotiable: maker proposes, verifier attacks, mechanical gate decides, ledger remembers.
+
+## Tickets
+
+### VERIFIER-CONTRACT-01 - Persist verification proposal and accepted contract before implementation
+
+**Journey:** `J-VERIFIER-CONTRACT-LIFECYCLE`
+
+Acceptance:
+- Feature-build can write `.specflow/runs/<slug>/verification-proposal.md` before maker implementation starts.
+- A verifier can accept or reject the proposal and write `.specflow/runs/<slug>/verification-contract.json` only on acceptance.
+- Rejected proposals block maker implementation and name the missing runtime/value/negative-path check.
+- The accepted contract includes journey ID, maker policy, verifier policy, runtime checks, forbidden evidence, and accepted timestamp.
+- Ledger entries reference proposal path, verifier decision, accepted contract path, and current mechanical gate state.
+- A provider exit code or maker summary cannot satisfy this ticket.
+
+### VERIFIER-POLICY-01 - Run verifier policy in isolated artifact/spec/rubric context
+
+**Journey:** `J-VERIFIER-POLICY-ISOLATION`
+
+Acceptance:
+- Adapter policy can declare a verifier policy distinct from maker policy.
+- Verifier input includes artifact path, outer spec/ticket, accepted verification contract, and rubric.
+- Verifier input excludes maker reasoning transcript by default.
+- Any exception that includes maker trace requires a human-recorded exception in the ledger.
+- Verifier output path and transcript path are separate from maker output and transcript paths.
+- Gate advance remains blocked until the owning mechanical gate reruns.
+
+### VERIFIER-RUNTIME-01 - Collect adversarial runtime evidence for UI/workflow slices
+
+**Journey:** `J-VERIFIER-RUNTIME-EVIDENCE`
+
+Acceptance:
+- Verification contracts can declare runtime checks of type `playwright`, `api`, `db-reread`, `console`, `network`, `screenshot`, or `custom-script`.
+- UI/workflow slices require at least one executable runtime check when the journey can pass static checks while failing in the app.
+- State-changing or value-bearing slices require an API, DB, or custom-script reread assertion; screenshot-only evidence is insufficient.
+- Runtime verifier findings are written to `verifier-findings.jsonl` with severity, check type, maker claim, verifier result, gate result, and evidence path.
+- Missing executable surface creates a blocked verifier finding instead of fabricated evidence.
+- Runtime verifier verdict is evidence only; the owning journey/mechanical gate still decides.
+
+### VERIFIER-TRACE-01 - Show maker claim, verifier finding, gate result, and divergence
+
+**Journey:** `J-VERIFIER-TRACE-DIVERGENCE`
+
+Acceptance:
+- `specflow run status`, `specflow run trace`, or the equivalent status surface can read verifier lifecycle ledger entries.
+- Output groups maker claim, verifier finding, mechanical gate result, and final disposition separately.
+- Divergence is highlighted when maker claims done but verifier fails, verifier passes but mechanical gate fails, evidence paths are missing, or a human-gated action is attempted.
+- Missing transcript/evidence/model fields are reported as missing or unknown, not inferred.
+- Trace does not send transcript content to a provider by default.
+- The output links the accepted verification contract and verifier finding paths.
+
+## Parent Issue Body Update
+
+#100 should remain the epic. Feature-build can implement these four tickets either as local slices or as child GitHub issues. If child issues are created, each body must include its journey ID and link back to #100.

--- a/docs/specs/verifier-runtime-lifecycle/verdict.md
+++ b/docs/specs/verifier-runtime-lifecycle/verdict.md
@@ -1,0 +1,18 @@
+# Verifier Runtime Lifecycle - Gate A Verdict
+
+**Date:** 2026-07-02
+**Verdict:** SHIP_WITH_STIPULATIONS
+**PRD:** `docs/specs/verifier-runtime-lifecycle/prd.md`
+**Adversary review:** `docs/specs/verifier-runtime-lifecycle/adversary-review.md`
+**Falsification:** `docs/specs/verifier-runtime-lifecycle/falsification.md`
+
+## Decision
+
+Ship to ticketing. The epic is necessary because #84/#92 otherwise risk collapsing into a reviewer prompt. The trusted product boundary is now explicit enough to ticket: provider output and verifier output are evidence, while mechanical gates decide.
+
+## Stipulations
+
+- Verifier approval never advances the run without the owning mechanical/journey gate.
+- Verifier context excludes maker reasoning trace by default.
+- Runtime verification is required for UI/workflow changes that can pass static checks while failing in the app.
+- Trace/status must preserve divergence instead of summarizing it away.

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -360,6 +360,142 @@ function defaultSpecDir(slug) {
   return join('docs', 'specs', slug);
 }
 
+// --- VERIFIER-CONTRACT-01 (epic #100): verification contract lifecycle -------
+// Maker proposes a slice-local verification contract; an independent verifier
+// accepts or rejects it BEFORE implementation. Acceptance is an explicit,
+// complete contract artifact — never a provider exit code or maker summary.
+
+const VERIFICATION_CONTRACT_FIELDS = [
+  'journey_id',
+  'maker_policy_id',
+  'verifier_policy_id',
+  'runtime_checks',
+  'forbidden_evidence',
+];
+
+function verificationPaths(options = {}) {
+  const base = options.runDir
+    || (options.contract ? dirname(options.contract) : dirname(defaultRunPaths(options.slug || 'run', options).contractPath));
+  return {
+    baseDir: base,
+    proposalPath: join(base, 'verification-proposal.md'),
+    contractPath: join(base, 'verification-contract.json'),
+    findingsPath: join(base, 'verifier-findings.jsonl'),
+    runtimeEvidenceDir: join(base, 'runtime-evidence'),
+    ledgerPath: options.ledger || join(base, 'ledger.jsonl'),
+  };
+}
+
+function writeVerificationProposal(options = {}) {
+  const paths = verificationPaths(options);
+  const journeyId = options.journeyId || options.journey_id;
+  if (!journeyId) throw new Error('writeVerificationProposal requires journeyId');
+  const runtimeChecks = options.runtimeChecks || options.runtime_checks || [];
+  const forbiddenEvidence = options.forbiddenEvidence || options.forbidden_evidence
+    || ['maker self-review', 'provider exit code as gate pass'];
+  const proposedAt = options.proposedAt || new Date().toISOString();
+  const content = [
+    `# Verification Proposal — ${journeyId}`,
+    '',
+    `- Proposed at: ${proposedAt}`,
+    `- Maker policy: ${options.makerPolicyId || options.maker_policy_id || UNKNOWN}`,
+    `- Verifier policy: ${options.verifierPolicyId || options.verifier_policy_id || UNKNOWN}`,
+    '',
+    '## Proposed runtime checks',
+    runtimeChecks.length
+      ? runtimeChecks.map((c) => `- [${c.type}] ${c.assertion || c.command || ''}${c.required ? ' (required)' : ''}`).join('\n')
+      : '- (none proposed — verifier must reject if this slice needs runtime/value/negative-path evidence)',
+    '',
+    '## Forbidden evidence',
+    forbiddenEvidence.map((f) => `- ${f}`).join('\n'),
+    '',
+    options.body ? `## Notes\n\n${options.body}\n` : '',
+  ].join('\n');
+  ensureDir(paths.proposalPath);
+  writeFileSync(paths.proposalPath, content, 'utf8');
+  appendLedger(paths.ledgerPath, {
+    stage: 'verification',
+    event: 'proposal_written',
+    journey_id: journeyId,
+    proposal_path: paths.proposalPath,
+    verification_contract_path: null,
+    verifier_decision: 'pending',
+    mechanical_gate_state: 'not_run',
+  });
+  return { proposalPath: paths.proposalPath, ledgerPath: paths.ledgerPath };
+}
+
+function decideVerification(options = {}) {
+  const paths = verificationPaths(options);
+  const decision = options.decision;
+  if (!['accept', 'reject'].includes(decision)) {
+    throw new Error("decideVerification requires decision 'accept' or 'reject'");
+  }
+  if (!existsSync(paths.proposalPath)) {
+    throw new Error('cannot decide verification before a proposal is written');
+  }
+
+  if (decision === 'reject') {
+    const missingCheck = options.missingCheck || options.missing_check;
+    if (!missingCheck) throw new Error('rejection must name the missing runtime/value/negative-path check');
+    appendLedger(paths.ledgerPath, {
+      stage: 'verification',
+      event: 'verifier_decision',
+      verifier_decision: 'rejected',
+      proposal_path: paths.proposalPath,
+      verification_contract_path: null,
+      missing_check: missingCheck,
+      blocks_implementation: true,
+      mechanical_gate_state: 'blocked',
+    });
+    return { ok: true, decision: 'rejected', blocksImplementation: true, contractPath: null };
+  }
+
+  const vc = options.verificationContract || options.verification_contract || {};
+  const missing = VERIFICATION_CONTRACT_FIELDS.filter((f) => {
+    const v = vc[f];
+    return v === undefined || v === null || v === '' || (Array.isArray(v) && v.length === 0);
+  });
+  if (missing.length) {
+    throw new Error(`accepted verification contract missing field(s): ${missing.join(', ')}`);
+  }
+  const acceptedAt = options.acceptedAt || vc.accepted_at || new Date().toISOString();
+  const contract = { ...vc, accepted_at: acceptedAt };
+  ensureDir(paths.contractPath);
+  writeFileSync(paths.contractPath, `${JSON.stringify(contract, null, 2)}\n`, 'utf8');
+  appendLedger(paths.ledgerPath, {
+    stage: 'verification',
+    event: 'verifier_decision',
+    verifier_decision: 'accepted',
+    proposal_path: paths.proposalPath,
+    verification_contract_path: paths.contractPath,
+    journey_id: contract.journey_id,
+    mechanical_gate_state: 'pending',
+  });
+  return { ok: true, decision: 'accepted', contractPath: paths.contractPath, contract };
+}
+
+function requireAcceptedVerificationContract(options = {}) {
+  const paths = verificationPaths(options);
+  if (!existsSync(paths.contractPath)) {
+    return { accepted: false, contractPath: paths.contractPath, reason: 'no accepted verification contract; maker implementation is blocked' };
+  }
+  let data;
+  try {
+    data = JSON.parse(readFileSync(paths.contractPath, 'utf8'));
+  } catch {
+    return { accepted: false, contractPath: paths.contractPath, reason: 'verification contract is not valid JSON' };
+  }
+  if (!data.accepted_at) {
+    return { accepted: false, contractPath: paths.contractPath, reason: 'verification contract missing accepted_at' };
+  }
+  const missing = VERIFICATION_CONTRACT_FIELDS.filter((f) => data[f] === undefined || data[f] === null);
+  if (missing.length) {
+    return { accepted: false, contractPath: paths.contractPath, reason: `verification contract missing: ${missing.join(', ')}` };
+  }
+  return { accepted: true, contractPath: paths.contractPath, contract: data, reason: null };
+}
+
 function verifierCommandsForStage(contract, options = {}) {
   const slug = options.slug || options.specSlug || contract.slug || 'specflow-run';
   const specDir = options.specDir || defaultSpecDir(slug);
@@ -1056,6 +1192,10 @@ module.exports = {
   executeVerifierRegistry,
   materializeStagePrompt,
   planAdapterSmoke,
+  verificationPaths,
+  writeVerificationProposal,
+  decideVerification,
+  requireAcceptedVerificationContract,
   readLedger,
   readLedgerTail,
   summarizeLedger,

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -1093,6 +1093,35 @@ function runLoop(options) {
 
   if (options.adapterPolicy) {
     const policy = normalizeAdapterPolicy(loadDataFile(options.adapterPolicy), { slug });
+
+    // VERIFIER-CONTRACT-01 enforcement (#100): a maker may not implement without
+    // an accepted verification contract. Enforced once the lifecycle has begun
+    // (a proposal exists) or when explicitly required; verifier runs are exempt.
+    if (contract.loop === 'feature-build' && contract.current_stage_or_rail === '5_impl' && policy.role !== 'verifier') {
+      const vpaths = verificationPaths({ contract: contractPath });
+      const proposalExists = existsSync(vpaths.proposalPath);
+      const enforce = options.requireVerifierContract === true
+        || (options.requireVerifierContract !== false && proposalExists);
+      if (enforce) {
+        const gate = requireAcceptedVerificationContract({ contract: contractPath });
+        if (!gate.accepted) {
+          const entry = {
+            stage: '5_impl',
+            event: 'impl_blocked',
+            result: 'fail',
+            stop_reason: 'verification_contract_required',
+            reason: gate.reason,
+            verification_contract_path: gate.contractPath,
+            mechanical_gate_state: 'blocked',
+          };
+          appendLedger(ledgerPath, entry);
+          contract.terminal_status = 'blocked';
+          writeYaml(contractPath, { run_contract: contract });
+          return { status: 'blocked_verification_required', entry, contractPath, ledgerPath };
+        }
+      }
+    }
+
     const prompt = options.prompt ? { promptPath: options.prompt } : materializeStagePrompt(contract, { ...options, contractPath, slug });
     const adapterResult = runAdapter(policy, {
       dryRun: options.adapterDryRun,

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -496,6 +496,63 @@ function requireAcceptedVerificationContract(options = {}) {
   return { accepted: true, contractPath: paths.contractPath, contract: data, reason: null };
 }
 
+// --- VERIFIER-POLICY-01 (epic #100): verifier policy isolation ---------------
+// The verifier policy is distinct from the maker policy (separate id and
+// output/transcript paths) and is fed artifact + spec + accepted verification
+// contract + rubric. The maker reasoning transcript is excluded by default;
+// including it requires a human-recorded ledger exception.
+
+function resolveVerifierPolicy(rawMaker, context = {}) {
+  const maker = normalizeAdapterPolicy(rawMaker, context);
+  if (!maker.verifier_policy) {
+    throw new Error('maker adapter_policy does not declare a verifier_policy');
+  }
+  const verifier = normalizeAdapterPolicy(maker.verifier_policy, context);
+  const errors = [];
+  if (verifier.id === maker.id) errors.push('verifier_policy.id must differ from maker policy id');
+  if (verifier.transcript_path === maker.transcript_path) errors.push('verifier transcript_path must differ from maker transcript_path');
+  if (verifier.output_path === maker.output_path) errors.push('verifier output_path must differ from maker output_path');
+  if (errors.length) throw new Error(`verifier policy not isolated: ${errors.join('; ')}`);
+  return { maker, verifier: { ...verifier, role: verifier.role || 'verifier' } };
+}
+
+function assembleVerifierInput(options = {}) {
+  const required = ['artifactPath', 'specPath', 'verificationContractPath', 'rubric'];
+  const missing = required.filter((k) => !options[k]);
+  if (missing.length) {
+    throw new Error(`verifier input missing required field(s): ${missing.join(', ')}`);
+  }
+  const input = {
+    artifact_path: options.artifactPath,
+    spec_path: options.specPath,
+    verification_contract_path: options.verificationContractPath,
+    rubric: options.rubric,
+    includes_maker_trace: false,
+    maker_transcript_path: null,
+  };
+  if (options.allowMakerTrace) {
+    const exception = options.humanException || options.human_exception || {};
+    const approvedBy = exception.approved_by || exception.approvedBy;
+    const reason = exception.reason;
+    if (!approvedBy || !reason) {
+      throw new Error('including the maker transcript requires a human exception with approved_by and reason');
+    }
+    input.includes_maker_trace = true;
+    input.maker_transcript_path = options.makerTranscriptPath || null;
+    input.maker_trace_exception = { approved_by: approvedBy, reason };
+    if (options.ledger) {
+      appendLedger(options.ledger, {
+        stage: 'verification',
+        event: 'verifier_maker_trace_exception',
+        approved_by: approvedBy,
+        reason,
+        maker_transcript_path: input.maker_transcript_path,
+      });
+    }
+  }
+  return input;
+}
+
 function verifierCommandsForStage(contract, options = {}) {
   const slug = options.slug || options.specSlug || contract.slug || 'specflow-run';
   const specDir = options.specDir || defaultSpecDir(slug);
@@ -1196,6 +1253,8 @@ module.exports = {
   writeVerificationProposal,
   decideVerification,
   requireAcceptedVerificationContract,
+  resolveVerifierPolicy,
+  assembleVerifierInput,
   readLedger,
   readLedgerTail,
   summarizeLedger,

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -553,6 +553,83 @@ function assembleVerifierInput(options = {}) {
   return input;
 }
 
+// --- VERIFIER-TRACE-01 (epic #100): maker/verifier/gate divergence surface ----
+// A pure read over the run ledger (+ verifier-findings). Groups maker claim,
+// verifier finding, mechanical gate result, and disposition; flags divergence.
+// Never sends transcript content to a provider; missing fields stay "missing".
+
+function verifierTrace(options = {}) {
+  const paths = verificationPaths(options);
+  const entries = readLedger(paths.ledgerPath);
+  const findings = existsSync(paths.findingsPath) ? readLedger(paths.findingsPath) : [];
+  const last = (pred) => entries.filter(pred).slice(-1)[0] || null;
+
+  const makerEntry = last((e) => e.event === 'maker_claim') || last((e) => e.stop_reason === 'gate_rerun_required');
+  const maker = makerEntry
+    ? {
+      claim: makerEntry.claim || (makerEntry.stop_reason === 'gate_rerun_required' ? 'produced_output' : UNKNOWN),
+      claimed_done: Boolean(makerEntry.claim === 'done' || makerEntry.claimed_done),
+      output_path: makerEntry.output_path || UNKNOWN,
+      transcript_path: makerEntry.transcript_path || UNKNOWN,
+    }
+    : { claim: 'missing', claimed_done: false, output_path: UNKNOWN, transcript_path: UNKNOWN };
+
+  const decisionEntry = last((e) => e.event === 'verifier_decision');
+  const failingFinding = findings.find((f) => f.result === 'fail' || f.severity === 'critical');
+  const verifier = (decisionEntry || findings.length)
+    ? {
+      decision: decisionEntry ? decisionEntry.verifier_decision : (failingFinding ? 'fail' : 'reported'),
+      missing_check: decisionEntry ? (decisionEntry.missing_check || null) : null,
+      finding_paths: findings.map((f) => f.evidence_path).filter(Boolean),
+      findings_count: findings.length,
+      verification_contract_path: decisionEntry ? (decisionEntry.verification_contract_path || null) : null,
+    }
+    : { decision: 'missing', missing_check: null, finding_paths: [], findings_count: 0, verification_contract_path: null };
+
+  const gateEntry = last((e) => ['pass', 'fail'].includes(e.result));
+  const stateEntry = last((e) => e.mechanical_gate_state);
+  const mechanicalGate = {
+    result: gateEntry ? gateEntry.result : 'not_run',
+    state: stateEntry ? stateEntry.mechanical_gate_state : UNKNOWN,
+  };
+
+  const contractGate = requireAcceptedVerificationContract(options);
+  const verifierFailed = verifier.decision === 'rejected' || Boolean(failingFinding);
+
+  const divergence = [];
+  if (maker.claimed_done && verifierFailed) divergence.push('maker_claimed_done_but_verifier_failed');
+  if (verifier.decision === 'accepted' && mechanicalGate.result === 'fail') divergence.push('verifier_passed_but_gate_failed');
+  const referenced = [
+    ...entries.map((e) => e.proposal_path),
+    ...entries.map((e) => e.verification_contract_path),
+    ...verifier.finding_paths,
+  ].filter(Boolean);
+  const missingEvidence = [...new Set(referenced)].filter((p) => !existsSync(p));
+  if (missingEvidence.length) divergence.push('missing_evidence');
+  if (entries.some((e) => e.stop_reason === 'blocked_human_required' || e.forbidden_action_detected)) {
+    divergence.push('human_gated_action_attempted');
+  }
+
+  let disposition = 'pending';
+  if (verifier.decision === 'rejected' || mechanicalGate.state === 'blocked') disposition = 'blocked';
+  else if (mechanicalGate.result === 'fail') disposition = 'gate_failed';
+  else if (mechanicalGate.result === 'pass' && contractGate.accepted) disposition = 'passed';
+
+  return {
+    status: 'ok',
+    run_dir: paths.baseDir,
+    ledger_path: paths.ledgerPath,
+    maker,
+    verifier,
+    mechanical_gate: mechanicalGate,
+    verification_contract: { path: contractGate.contractPath, accepted: contractGate.accepted, reason: contractGate.reason },
+    disposition,
+    divergence,
+    missing_evidence: missingEvidence,
+    sends_transcript_to_provider: false,
+  };
+}
+
 function verifierCommandsForStage(contract, options = {}) {
   const slug = options.slug || options.specSlug || contract.slug || 'specflow-run';
   const specDir = options.specDir || defaultSpecDir(slug);
@@ -1135,6 +1212,7 @@ function runStatus(options = {}) {
     sequence: loopSequence(contract, options),
     ledger_summary: summarizeLedger(readLedger(ledgerPath)),
     ledger_tail: readLedgerTail(ledgerPath, Number(options.limit || 10)),
+    verifier_trace: verifierTrace({ contract: contractPath, ledger: ledgerPath }),
   };
 }
 
@@ -1198,13 +1276,18 @@ function cli(argv = process.argv.slice(2)) {
   const opts = parseKeyValueArgs(argv);
   const loop = opts._[0];
   if (!loop) {
-    console.error('Usage: specflow run <loop|status> --slug <slug> --goal <goal> --input <path> [--contract path] [--until-terminal] [--max-iterations n]');
+    console.error('Usage: specflow run <loop|status|trace> --slug <slug> --goal <goal> --input <path> [--contract path] [--run-dir path] [--until-terminal] [--max-iterations n]');
     return 2;
   }
   try {
-    const result = loop === 'status'
-      ? runStatus(opts)
-      : (opts.untilTerminal ? runUntilTerminal({ ...opts, loop }) : runLoop({ ...opts, loop }));
+    let result;
+    if (loop === 'status') {
+      result = runStatus(opts);
+    } else if (loop === 'trace') {
+      result = verifierTrace({ runDir: opts.runDir, contract: opts.contract, ledger: opts.ledger });
+    } else {
+      result = opts.untilTerminal ? runUntilTerminal({ ...opts, loop }) : runLoop({ ...opts, loop });
+    }
     if (result.status === 'invalid_contract') {
       console.error(`specflow run failed: ${result.errors.join('; ')}`);
       return 1;
@@ -1255,6 +1338,7 @@ module.exports = {
   requireAcceptedVerificationContract,
   resolveVerifierPolicy,
   assembleVerifierInput,
+  verifierTrace,
   readLedger,
   readLedgerTail,
   summarizeLedger,

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -553,6 +553,84 @@ function assembleVerifierInput(options = {}) {
   return input;
 }
 
+// --- VERIFIER-RUNTIME-01 (epic #100): adversarial runtime evidence -----------
+// Verification contracts declare runtime checks; the verifier executes them and
+// writes findings. Missing executable surface yields a BLOCKED finding, never
+// fabricated evidence. The verdict is evidence only — the gate still decides.
+
+const RUNTIME_CHECK_TYPES = ['playwright', 'api', 'db-reread', 'console', 'network', 'screenshot', 'custom-script'];
+const RUNTIME_REREAD_TYPES = ['api', 'db-reread', 'custom-script'];
+
+function validateRuntimeChecks(checks, options = {}) {
+  const list = Array.isArray(checks) ? checks : [];
+  const errors = [];
+  for (const c of list) {
+    if (!c || !RUNTIME_CHECK_TYPES.includes(c.type)) errors.push(`unsupported runtime check type: ${c && c.type}`);
+  }
+  if (options.uiOrWorkflow && !list.some((c) => c && c.required)) {
+    errors.push('UI/workflow slice requires at least one required runtime check');
+  }
+  if (options.valueBearing && !list.some((c) => c && RUNTIME_REREAD_TYPES.includes(c.type))) {
+    errors.push('value-bearing slice requires an api/db-reread/custom-script reread; screenshot-only evidence is insufficient');
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+function defaultRuntimeRunner(check) {
+  if (!check.command) return { executable: false };
+  const res = runCommand(check.command, { timeoutSeconds: check.timeout_seconds });
+  return { executable: true, result: res.exit_code === 0 ? 'pass' : 'fail', exit_code: res.exit_code, stderr: res.stderr };
+}
+
+function runRuntimeChecks(options = {}) {
+  const paths = verificationPaths(options);
+  const checks = Array.isArray(options.checks) ? options.checks : [];
+  const makerClaim = options.makerClaim || UNKNOWN;
+  const runner = options.runner || defaultRuntimeRunner;
+  const findings = [];
+  for (const check of checks) {
+    const outcome = runner(check) || {};
+    let finding;
+    if (outcome.executable === false || outcome.result === 'blocked') {
+      finding = {
+        severity: 'blocked',
+        check_type: check.type,
+        assertion: check.assertion || null,
+        maker_claim: makerClaim,
+        verifier_result: 'blocked',
+        result: 'blocked',
+        gate_result: 'pending',
+        evidence_path: null,
+        reason: outcome.reason || `missing executable surface for ${check.type} check`,
+      };
+    } else {
+      const failed = outcome.result === 'fail';
+      finding = {
+        severity: failed ? (check.required ? 'critical' : 'warn') : 'info',
+        check_type: check.type,
+        assertion: check.assertion || null,
+        maker_claim: makerClaim,
+        verifier_result: outcome.result,
+        result: outcome.result,
+        gate_result: 'pending', // evidence only — the mechanical gate still decides
+        evidence_path: outcome.evidence_path || check.evidence_path || null,
+      };
+    }
+    findings.push(finding);
+    appendLedger(paths.findingsPath, finding);
+  }
+  return {
+    findings,
+    findingsPath: paths.findingsPath,
+    summary: {
+      total: findings.length,
+      pass: findings.filter((f) => f.verifier_result === 'pass').length,
+      fail: findings.filter((f) => f.verifier_result === 'fail').length,
+      blocked: findings.filter((f) => f.verifier_result === 'blocked').length,
+    },
+  };
+}
+
 // --- VERIFIER-TRACE-01 (epic #100): maker/verifier/gate divergence surface ----
 // A pure read over the run ledger (+ verifier-findings). Groups maker claim,
 // verifier finding, mechanical gate result, and disposition; flags divergence.
@@ -1367,6 +1445,8 @@ module.exports = {
   requireAcceptedVerificationContract,
   resolveVerifierPolicy,
   assembleVerifierInput,
+  validateRuntimeChecks,
+  runRuntimeChecks,
   verifierTrace,
   readLedger,
   readLedgerTail,

--- a/tests/contracts/verifier-contract-lifecycle.test.js
+++ b/tests/contracts/verifier-contract-lifecycle.test.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  writeVerificationProposal,
+  decideVerification,
+  requireAcceptedVerificationContract,
+  verificationPaths,
+} = require('../../scripts/specflow-runner.cjs');
+
+// VERIFIER-CONTRACT-01 / J-VERIFIER-CONTRACT-LIFECYCLE (epic #100)
+// Trust boundary: maker proposes, verifier decides, mechanical gate still owns pass/fail.
+
+function tempRun() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-verif-'));
+}
+function readJsonl(file) {
+  return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+function sampleContract(overrides = {}) {
+  return {
+    journey_id: 'J-VERIFIER-CONTRACT-LIFECYCLE',
+    maker_policy_id: 'claude-print-maker',
+    verifier_policy_id: 'codex-exec-verifier',
+    runtime_checks: [
+      { type: 'playwright', command: 'npx playwright test j.spec.ts', assertion: 'flow completes', required: true },
+    ],
+    forbidden_evidence: ['maker self-review', 'provider exit code as gate pass'],
+    ...overrides,
+  };
+}
+
+describe('VERIFIER-CONTRACT-01 — verification contract lifecycle (J-VERIFIER-CONTRACT-LIFECYCLE)', () => {
+  test('writes verification-proposal.md before implementation and blocks until accepted', () => {
+    const runDir = tempRun();
+    const { proposalPath } = writeVerificationProposal({
+      runDir,
+      journeyId: 'J-VERIFIER-CONTRACT-LIFECYCLE',
+      makerPolicyId: 'claude-print-maker',
+      verifierPolicyId: 'codex-exec-verifier',
+      runtimeChecks: sampleContract().runtime_checks,
+    });
+    expect(fs.existsSync(proposalPath)).toBe(true);
+
+    // No accepted contract yet → maker implementation is blocked.
+    const gate = requireAcceptedVerificationContract({ runDir });
+    expect(gate.accepted).toBe(false);
+    expect(gate.reason).toMatch(/blocked/);
+    expect(fs.existsSync(verificationPaths({ runDir }).contractPath)).toBe(false);
+  });
+
+  test('acceptance writes verification-contract.json with required fields + accepted_at and unblocks', () => {
+    const runDir = tempRun();
+    writeVerificationProposal({
+      runDir, journeyId: 'J-VERIFIER-CONTRACT-LIFECYCLE', makerPolicyId: 'm', verifierPolicyId: 'v',
+      runtimeChecks: sampleContract().runtime_checks,
+    });
+    const res = decideVerification({
+      runDir, decision: 'accept', verificationContract: sampleContract(), acceptedAt: '2026-07-02T00:00:00.000Z',
+    });
+    expect(res.decision).toBe('accepted');
+
+    const gate = requireAcceptedVerificationContract({ runDir });
+    expect(gate.accepted).toBe(true);
+    const saved = JSON.parse(fs.readFileSync(gate.contractPath, 'utf8'));
+    for (const f of ['journey_id', 'maker_policy_id', 'verifier_policy_id', 'runtime_checks', 'forbidden_evidence', 'accepted_at']) {
+      expect(saved[f]).toBeDefined();
+    }
+    expect(saved.accepted_at).toBe('2026-07-02T00:00:00.000Z');
+  });
+
+  test('rejection does not write a contract, blocks implementation, and names the missing check', () => {
+    const runDir = tempRun();
+    writeVerificationProposal({ runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: [] });
+    const res = decideVerification({
+      runDir, decision: 'reject', missingCheck: 'no value-bearing API reread for the state change',
+    });
+    expect(res.decision).toBe('rejected');
+    expect(res.blocksImplementation).toBe(true);
+    expect(fs.existsSync(verificationPaths({ runDir }).contractPath)).toBe(false);
+    expect(requireAcceptedVerificationContract({ runDir }).accepted).toBe(false);
+
+    const rej = readJsonl(verificationPaths({ runDir }).ledgerPath).find((e) => e.verifier_decision === 'rejected');
+    expect(rej.missing_check).toMatch(/reread/);
+    expect(rej.blocks_implementation).toBe(true);
+    expect(rej.verification_contract_path).toBeNull();
+  });
+
+  test('ledger references proposal path, verifier decision, accepted contract path, and mechanical gate state', () => {
+    const runDir = tempRun();
+    const { proposalPath } = writeVerificationProposal({
+      runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: sampleContract().runtime_checks,
+    });
+    decideVerification({ runDir, decision: 'accept', verificationContract: sampleContract() });
+
+    const led = readJsonl(verificationPaths({ runDir }).ledgerPath);
+    expect(led.find((e) => e.event === 'proposal_written').proposal_path).toBe(proposalPath);
+
+    const accepted = led.find((e) => e.verifier_decision === 'accepted');
+    expect(accepted.proposal_path).toBe(proposalPath);
+    expect(accepted.verification_contract_path).toBe(verificationPaths({ runDir }).contractPath);
+    expect(accepted.mechanical_gate_state).toBe('pending'); // gate has NOT run — verifier acceptance is not a pass
+  });
+
+  test('a provider exit code or maker summary cannot satisfy the ticket', () => {
+    const runDir = tempRun();
+    // Cannot accept before a proposal exists (no implicit acceptance from a prior adapter run).
+    expect(() => decideVerification({ runDir, decision: 'accept', verificationContract: sampleContract() }))
+      .toThrow(/proposal/);
+
+    // Acceptance requires an explicit, complete verification contract — not a truthy adapter result.
+    writeVerificationProposal({ runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: sampleContract().runtime_checks });
+    expect(() => decideVerification({ runDir, decision: 'accept', verificationContract: { journey_id: 'J' } }))
+      .toThrow(/missing field/);
+    expect(requireAcceptedVerificationContract({ runDir }).accepted).toBe(false);
+  });
+});

--- a/tests/contracts/verifier-impl-rail.test.js
+++ b/tests/contracts/verifier-impl-rail.test.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const {
+  runLoop,
+  writeVerificationProposal,
+  decideVerification,
+  verificationPaths,
+} = require('../../scripts/specflow-runner.cjs');
+
+// VERIFIER-CONTRACT-01 enforcement in the feature-build 5_impl rail (epic #100).
+
+function setup(overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-implrail-'));
+  const runDir = path.join(dir, '.specflow/runs/slice');
+  fs.mkdirSync(runDir, { recursive: true });
+  const contractPath = path.join(runDir, 'run-contract.yaml');
+  const ledgerPath = path.join(runDir, 'ledger.jsonl');
+  fs.writeFileSync(contractPath, yaml.dump({
+    run_contract: {
+      loop: 'feature-build',
+      goal: 'implement slice',
+      input_artifact: 'docs/x.md',
+      path: 'templates/QA/loops/feature-build.yaml',
+      current_stage_or_rail: '5_impl',
+      next_gate: 'implementation',
+      durable_evidence: [contractPath],
+      stop_condition: 'handoff',
+      never_without_human: ['git push'],
+      storage: { contract_path: contractPath, ledger_path: ledgerPath },
+    },
+  }));
+  const policyPath = path.join(dir, 'maker.yaml');
+  fs.writeFileSync(policyPath, yaml.dump({
+    adapter_policy: {
+      id: 'fake-maker',
+      provider: 'fake',
+      command: 'fake',
+      role: 'implementer',
+      timeout_seconds: 10,
+      max_iterations: 1,
+      transcript_path: path.join(runDir, 'maker/transcript.jsonl'),
+      output_path: path.join(runDir, 'maker/output.md'),
+      dry_run: true,
+      never_without_human: ['git push'],
+      ...overrides.policy,
+    },
+  }));
+  const promptPath = path.join(dir, 'prompt.md');
+  fs.writeFileSync(promptPath, '# stage prompt');
+  return { runDir, contractPath, ledgerPath, policyPath, promptPath };
+}
+
+function run(env) {
+  return runLoop({
+    slug: 'slice', contract: env.contractPath, ledger: env.ledgerPath,
+    adapterPolicy: env.policyPath, prompt: env.promptPath,
+  });
+}
+
+describe('VERIFIER-CONTRACT-01 impl-rail enforcement (#100)', () => {
+  test('blocks the maker at 5_impl when a proposal exists but no contract is accepted', () => {
+    const env = setup();
+    writeVerificationProposal({
+      runDir: env.runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v',
+      runtimeChecks: [{ type: 'api', assertion: 'reread', required: true }],
+    });
+
+    const res = run(env);
+    expect(res.status).toBe('blocked_verification_required');
+    expect(fs.existsSync(path.join(env.runDir, 'maker/output.md'))).toBe(false); // adapter never ran
+    const blocked = fs.readFileSync(env.ledgerPath, 'utf8').split('\n').filter(Boolean).map(JSON.parse)
+      .find((e) => e.event === 'impl_blocked');
+    expect(blocked.stop_reason).toBe('verification_contract_required');
+  });
+
+  test('proceeds once the verification contract is accepted', () => {
+    const env = setup();
+    writeVerificationProposal({
+      runDir: env.runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v',
+      runtimeChecks: [{ type: 'api', assertion: 'reread', required: true }],
+    });
+    decideVerification({
+      runDir: env.runDir, decision: 'accept',
+      verificationContract: {
+        journey_id: 'J', maker_policy_id: 'm', verifier_policy_id: 'v',
+        runtime_checks: [{ type: 'api', assertion: 'reread', required: true }],
+        forbidden_evidence: ['maker self-review'],
+      },
+    });
+
+    const res = run(env);
+    expect(res.status).not.toBe('blocked_verification_required');
+    expect(res.status).toBe('dry_run'); // fake maker policy runs (dry_run)
+  });
+
+  test('does not block runs that never started the verifier lifecycle (backward compatible)', () => {
+    const env = setup();
+    expect(fs.existsSync(verificationPaths({ runDir: env.runDir }).proposalPath)).toBe(false);
+    const res = run(env);
+    expect(res.status).toBe('dry_run');
+  });
+});

--- a/tests/contracts/verifier-policy-isolation.test.js
+++ b/tests/contracts/verifier-policy-isolation.test.js
@@ -1,0 +1,121 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  resolveVerifierPolicy,
+  assembleVerifierInput,
+  requireAcceptedVerificationContract,
+  verificationPaths,
+} = require('../../scripts/specflow-runner.cjs');
+
+// VERIFIER-POLICY-01 / J-VERIFIER-POLICY-ISOLATION (epic #100)
+// The verifier runs from artifact + spec + accepted contract + rubric — NOT the
+// maker reasoning trace — and writes to paths separate from the maker.
+
+function tempRun() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-vpol-'));
+}
+function readJsonl(file) {
+  return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+function verifierPolicyObj(overrides = {}) {
+  return {
+    id: 'codex-exec-verifier',
+    provider: 'codex-exec',
+    command: 'codex',
+    role: 'verifier',
+    timeout_seconds: 600,
+    max_iterations: 1,
+    transcript_path: '.specflow/runs/<slug>/verifier/transcript.jsonl',
+    output_path: '.specflow/runs/<slug>/verifier/finding.md',
+    never_without_human: ['git push', 'open PR', 'merge'],
+    ...overrides,
+  };
+}
+function makerPolicyObj(adapterOverrides = {}) {
+  return {
+    adapter_policy: {
+      id: 'claude-print-maker',
+      provider: 'claude-print',
+      command: 'claude',
+      role: 'implementer',
+      timeout_seconds: 900,
+      max_iterations: 1,
+      transcript_path: '.specflow/runs/<slug>/maker/transcript.jsonl',
+      output_path: '.specflow/runs/<slug>/maker/output.md',
+      never_without_human: ['git push', 'open PR', 'merge'],
+      verifier_policy: verifierPolicyObj(),
+      ...adapterOverrides,
+    },
+  };
+}
+
+describe('VERIFIER-POLICY-01 — verifier policy isolation (J-VERIFIER-POLICY-ISOLATION)', () => {
+  test('resolves a verifier policy distinct from the maker policy with separate paths', () => {
+    const { maker, verifier } = resolveVerifierPolicy(makerPolicyObj(), { slug: 'demo' });
+    expect(verifier.id).not.toBe(maker.id);
+    expect(verifier.transcript_path).not.toBe(maker.transcript_path);
+    expect(verifier.output_path).not.toBe(maker.output_path);
+    expect(verifier.role).toBe('verifier');
+  });
+
+  test('rejects a verifier policy that shares the maker output or transcript path', () => {
+    const shared = makerPolicyObj({
+      verifier_policy: verifierPolicyObj({ output_path: '.specflow/runs/<slug>/maker/output.md' }),
+    });
+    expect(() => resolveVerifierPolicy(shared, { slug: 'demo' })).toThrow(/output_path must differ/);
+  });
+
+  test('throws when no verifier policy is declared', () => {
+    const noVerifier = makerPolicyObj({ verifier_policy: undefined });
+    expect(() => resolveVerifierPolicy(noVerifier, { slug: 'demo' })).toThrow(/does not declare a verifier_policy/);
+  });
+
+  test('verifier input includes artifact/spec/contract/rubric and excludes the maker trace by default', () => {
+    const input = assembleVerifierInput({
+      artifactPath: '.specflow/runs/demo/maker/output.md',
+      specPath: 'docs/specs/verifier-runtime-lifecycle/tickets.md',
+      verificationContractPath: '.specflow/runs/demo/verification-contract.json',
+      rubric: 'attack the running slice; refute by default',
+      makerTranscriptPath: '.specflow/runs/demo/maker/transcript.jsonl',
+    });
+    expect(input.artifact_path).toBeTruthy();
+    expect(input.spec_path).toBeTruthy();
+    expect(input.verification_contract_path).toBeTruthy();
+    expect(input.rubric).toBeTruthy();
+    expect(input.includes_maker_trace).toBe(false);
+    expect(input.maker_transcript_path).toBeNull();
+  });
+
+  test('including the maker trace requires a human-recorded exception', () => {
+    const base = {
+      artifactPath: 'a', specPath: 's', verificationContractPath: 'c', rubric: 'r',
+      makerTranscriptPath: 't', allowMakerTrace: true,
+    };
+    expect(() => assembleVerifierInput(base)).toThrow(/human exception/);
+  });
+
+  test('a human exception records the maker-trace inclusion in the ledger', () => {
+    const runDir = tempRun();
+    const ledger = verificationPaths({ runDir }).ledgerPath;
+    const input = assembleVerifierInput({
+      artifactPath: 'a', specPath: 's', verificationContractPath: 'c', rubric: 'r',
+      makerTranscriptPath: '.specflow/runs/x/maker/transcript.jsonl',
+      allowMakerTrace: true,
+      humanException: { approved_by: 'colm', reason: 'flaky runtime surface; need maker context once' },
+      ledger,
+    });
+    expect(input.includes_maker_trace).toBe(true);
+    const entry = readJsonl(ledger).find((e) => e.event === 'verifier_maker_trace_exception');
+    expect(entry.approved_by).toBe('colm');
+    expect(entry.reason).toMatch(/flaky/);
+  });
+
+  test('assembling verifier input has no gate side effect (mechanical gate still owns pass)', () => {
+    const runDir = tempRun();
+    assembleVerifierInput({ artifactPath: 'a', specPath: 's', verificationContractPath: 'c', rubric: 'r' });
+    expect(fs.existsSync(verificationPaths({ runDir }).contractPath)).toBe(false);
+    expect(requireAcceptedVerificationContract({ runDir }).accepted).toBe(false);
+  });
+});

--- a/tests/contracts/verifier-runtime-evidence.test.js
+++ b/tests/contracts/verifier-runtime-evidence.test.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  validateRuntimeChecks,
+  runRuntimeChecks,
+  verifierTrace,
+  verificationPaths,
+} = require('../../scripts/specflow-runner.cjs');
+
+// VERIFIER-RUNTIME-01 / J-VERIFIER-RUNTIME-EVIDENCE (epic #100)
+
+function tempRun() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-vrt-'));
+}
+function readJsonl(file) {
+  return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+const PASS = 'node -e "process.exit(0)"';
+const FAIL = 'node -e "process.exit(1)"';
+
+describe('VERIFIER-RUNTIME-01 — runtime evidence (J-VERIFIER-RUNTIME-EVIDENCE)', () => {
+  test('validates check types and UI / value-bearing requirements', () => {
+    expect(validateRuntimeChecks([{ type: 'bogus' }]).ok).toBe(false);
+    expect(validateRuntimeChecks([{ type: 'playwright' }], { uiOrWorkflow: true }).ok).toBe(false); // none required
+    expect(validateRuntimeChecks([{ type: 'playwright', required: true }], { uiOrWorkflow: true }).ok).toBe(true);
+
+    const screenshotOnly = validateRuntimeChecks([{ type: 'screenshot', required: true }], { valueBearing: true });
+    expect(screenshotOnly.ok).toBe(false);
+    expect(screenshotOnly.errors.join()).toMatch(/screenshot-only/);
+    expect(validateRuntimeChecks([{ type: 'api', required: true }], { valueBearing: true }).ok).toBe(true);
+  });
+
+  test('executes checks and records findings with the required fields (verdict is evidence only)', () => {
+    const runDir = tempRun();
+    const { findings, summary } = runRuntimeChecks({
+      runDir,
+      makerClaim: 'done',
+      checks: [
+        { type: 'api', command: PASS, assertion: 'reread returns 200', required: true },
+        { type: 'playwright', command: FAIL, assertion: 'space bar moves player', required: true },
+      ],
+    });
+    expect(summary).toMatchObject({ total: 2, pass: 1, fail: 1 });
+
+    const written = readJsonl(verificationPaths({ runDir }).findingsPath);
+    for (const f of written) {
+      for (const field of ['severity', 'check_type', 'maker_claim', 'verifier_result', 'gate_result']) {
+        expect(f[field]).toBeDefined();
+      }
+      expect(f.gate_result).toBe('pending'); // never a gate pass
+    }
+    expect(findings.find((f) => f.check_type === 'playwright').severity).toBe('critical');
+  });
+
+  test('missing executable surface yields a BLOCKED finding, not fabricated evidence', () => {
+    const runDir = tempRun();
+    const { findings } = runRuntimeChecks({
+      runDir,
+      checks: [{ type: 'api', assertion: 'reread the created row', required: true }], // no command
+    });
+    expect(findings[0].verifier_result).toBe('blocked');
+    expect(findings[0].severity).toBe('blocked');
+    expect(findings[0].reason).toMatch(/missing executable surface/);
+    expect(findings[0].evidence_path).toBeNull();
+  });
+
+  test('a supported runner can inject results (no real browser needed)', () => {
+    const runDir = tempRun();
+    const runner = (c) => ({ executable: true, result: 'pass', evidence_path: `runtime-evidence/${c.type}.png` });
+    const { findings } = runRuntimeChecks({
+      runDir, checks: [{ type: 'screenshot', assertion: 'renders', required: true }], runner,
+    });
+    expect(findings[0].verifier_result).toBe('pass');
+    expect(findings[0].evidence_path).toMatch(/screenshot\.png/);
+  });
+
+  test('findings feed the trace surface as verifier evidence', () => {
+    const runDir = tempRun();
+    fs.appendFileSync(verificationPaths({ runDir }).ledgerPath,
+      `${JSON.stringify({ event: 'maker_claim', claim: 'done' })}\n`);
+    runRuntimeChecks({ runDir, makerClaim: 'done', checks: [{ type: 'api', command: FAIL, assertion: 'reread', required: true }] });
+
+    const t = verifierTrace({ runDir });
+    expect(t.verifier.findings_count).toBe(1);
+    expect(t.divergence).toContain('maker_claimed_done_but_verifier_failed');
+  });
+});

--- a/tests/contracts/verifier-trace-divergence.test.js
+++ b/tests/contracts/verifier-trace-divergence.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  writeVerificationProposal,
+  decideVerification,
+  verifierTrace,
+  verificationPaths,
+  appendLedger,
+  cli,
+} = require('../../scripts/specflow-runner.cjs');
+
+// VERIFIER-TRACE-01 / J-VERIFIER-TRACE-DIVERGENCE (epic #100)
+
+function tempRun() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-vtrace-'));
+}
+function contract(overrides = {}) {
+  return {
+    journey_id: 'J', maker_policy_id: 'm', verifier_policy_id: 'v',
+    runtime_checks: [{ type: 'api', command: 'curl', assertion: 'reread', required: true }],
+    forbidden_evidence: ['maker self-review'], ...overrides,
+  };
+}
+
+describe('VERIFIER-TRACE-01 — maker/verifier/gate divergence (J-VERIFIER-TRACE-DIVERGENCE)', () => {
+  test('groups maker claim, verifier finding, gate result separately and never posts transcript', () => {
+    const runDir = tempRun();
+    writeVerificationProposal({ runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: contract().runtime_checks });
+    decideVerification({ runDir, decision: 'accept', verificationContract: contract() });
+
+    const t = verifierTrace({ runDir });
+    expect(t.verifier.decision).toBe('accepted');
+    expect(t.mechanical_gate.result).toBe('not_run'); // gate has not run — acceptance is not a pass
+    expect(t.disposition).toBe('pending');
+    expect(t.sends_transcript_to_provider).toBe(false);
+  });
+
+  test('flags verifier_passed_but_gate_failed', () => {
+    const runDir = tempRun();
+    writeVerificationProposal({ runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: contract().runtime_checks });
+    decideVerification({ runDir, decision: 'accept', verificationContract: contract() });
+    appendLedger(verificationPaths({ runDir }).ledgerPath, { stage: '6_provenance', verifier: 'provenance', result: 'fail', stop_reason: 'gate_failed' });
+
+    const t = verifierTrace({ runDir });
+    expect(t.mechanical_gate.result).toBe('fail');
+    expect(t.divergence).toContain('verifier_passed_but_gate_failed');
+    expect(t.disposition).toBe('gate_failed');
+  });
+
+  test('flags maker_claimed_done_but_verifier_failed and dispositions blocked', () => {
+    const runDir = tempRun();
+    writeVerificationProposal({ runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: [] });
+    appendLedger(verificationPaths({ runDir }).ledgerPath, { event: 'maker_claim', claim: 'done', output_path: '/x/output.md' });
+    decideVerification({ runDir, decision: 'reject', missingCheck: 'no value-bearing reread' });
+
+    const t = verifierTrace({ runDir });
+    expect(t.maker.claimed_done).toBe(true);
+    expect(t.verifier.decision).toBe('rejected');
+    expect(t.divergence).toContain('maker_claimed_done_but_verifier_failed');
+    expect(t.disposition).toBe('blocked');
+  });
+
+  test('reports missing maker/verifier and missing evidence without inferring', () => {
+    const runDir = tempRun();
+    appendLedger(verificationPaths({ runDir }).ledgerPath, {
+      event: 'proposal_written', proposal_path: path.join(runDir, 'does-not-exist.md'), verification_contract_path: null,
+    });
+    const t = verifierTrace({ runDir });
+    expect(t.maker.claim).toBe('missing');
+    expect(t.verifier.decision).toBe('missing');
+    expect(t.divergence).toContain('missing_evidence');
+  });
+
+  test('flags human_gated_action_attempted', () => {
+    const runDir = tempRun();
+    appendLedger(verificationPaths({ runDir }).ledgerPath, { stage: '5_impl', stop_reason: 'blocked_human_required', forbidden_action_detected: 'git push' });
+    expect(verifierTrace({ runDir }).divergence).toContain('human_gated_action_attempted');
+  });
+
+  test('CLI `trace` verb reads the run directory', () => {
+    const runDir = tempRun();
+    writeVerificationProposal({ runDir, journeyId: 'J', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: contract().runtime_checks });
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const code = cli(['trace', '--run-dir', runDir]);
+    spy.mockRestore();
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Feature-builds epic **#100** (runtime verifier contract lifecycle for frontier agents) from the spec-built packet in `docs/specs/verifier-runtime-lifecycle/`.

## Slices (all test-first, gated by the full suite)
- **VERIFIER-CONTRACT-01** (`J-VERIFIER-CONTRACT-LIFECYCLE`) — persist `verification-proposal.md` + accepted `verification-contract.json` before implementation; accept/reject writes separate ledger entries; acceptance is never derived from a provider exit code or maker summary.
- **VERIFIER-POLICY-01** (`J-VERIFIER-POLICY-ISOLATION`) — verifier policy distinct from maker (separate id + output/transcript paths); input = artifact + spec + accepted contract + rubric; maker reasoning trace excluded unless a human exception is ledgered.
- **impl-rail enforcement** — `runLoop` blocks a feature-build maker at `5_impl` until an accepted contract exists (`blocked_verification_required`); backward-compatible for runs that never start the lifecycle.
- **VERIFIER-TRACE-01** (`J-VERIFIER-TRACE-DIVERGENCE`) — `specflow run status` / new `specflow run trace` group maker claim vs verifier finding vs mechanical gate and flag divergence; pure local read, never posts transcript to a provider.
- **VERIFIER-RUNTIME-01** (`J-VERIFIER-RUNTIME-EVIDENCE`) — validate/execute runtime checks into `verifier-findings.jsonl`; missing executable surface → **blocked** finding (no fabricated evidence); `gate_result` stays `pending` — the mechanical gate still decides.

## Trust boundary
Provider output/exit code is never a verdict. Verifier acceptance and runtime findings are evidence only; the deterministic gate owns pass/fail (epic REQ-04/07).

## Verification
- 26 new tests across 5 suites.
- Full suite: **819/819 across 31 suites**, green after every slice (baseline 798, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)