### PR TITLE
feat: enforced runtime verifier stage — VERIFIER-RAIL-01 (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Contract tests scan your source code for forbidden patterns. Break a rule → bu
 
 ---
 
+## The Invariant
+
+> **Frontier-model scaffolding is disposable. Gates, ledger, state, verifier evidence, and human boundaries are not.**
+
+As models get stronger they need less prompt scaffolding — so prompts, skills, and sprint decomposition are expected to come and go. What does **not** move is the trust layer: a provider's output (or exit code) is never a verdict; the mechanical gate decides, the ledger remembers, and unsafe boundaries stay human-authorized.
+
+---
+
 ## Install
 
 ```bash

--- a/examples/verifier-rail-proof/journey.js
+++ b/examples/verifier-rail-proof/journey.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/*
+ * AC8 proof (issue #102): a runnable journey that FAILS when the app only
+ * "looks done". The verifier rail wires this as a runtime check; a failing
+ * journey blocks gate advancement — the exact frontier-model trap (plausible
+ * UI, dead behavior) that static contract checks miss.
+ *
+ *   node journey.js                 -> PASS (behavior works)
+ *   BEHAVIOR_BUG=1 node journey.js  -> FAIL (space does nothing)
+ *
+ * The production form is journey.spec.ts (real Playwright against the live app).
+ */
+
+function makeApp({ bug }) {
+  const state = { x: 0 };
+  return {
+    render: () => '<canvas id="game"></canvas><button>Play</button>', // renders — looks done
+    pressSpace: () => { if (!bug) state.x += 1; },                     // behavior — dead when bug
+    x: () => state.x,
+  };
+}
+
+const app = makeApp({ bug: process.env.BEHAVIOR_BUG === '1' });
+
+// A static/screenshot check would pass here: the UI renders a canvas + Play button.
+if (!app.render().includes('<canvas')) {
+  console.error('FAIL: no canvas rendered');
+  process.exit(1);
+}
+
+// The runtime journey — this is what static checks cannot see.
+app.pressSpace();
+if (app.x() === 0) {
+  console.error('FAIL: pressing space did not move the player (dead behavior behind a done-looking UI)');
+  process.exit(1);
+}
+
+console.log('PASS: space moves the player');
+process.exit(0);

--- a/examples/verifier-rail-proof/journey.spec.ts
+++ b/examples/verifier-rail-proof/journey.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+/*
+ * Production form of the AC8 proof (issue #102) — the real runtime adversary.
+ * Run with: npx playwright test examples/verifier-rail-proof/journey.spec.ts
+ *
+ * A verification contract declares this as a runtime check of type `playwright`.
+ * The verifier rail runs it in a separate context and writes the result to
+ * verifier-findings.jsonl; the gate consumes that finding, not the maker's claim.
+ * A "looks done" UI with dead behavior FAILS here — which blocks the gate.
+ */
+test('J-VERIFIER-RAIL: pressing space moves the player', async ({ page }) => {
+  await page.goto(process.env.APP_URL || 'http://localhost:3000');
+
+  // Static-ish: the UI renders. On its own this is weak evidence.
+  await expect(page.locator('canvas#game')).toBeVisible();
+
+  // Runtime behavior: the value-bearing assertion static checks cannot make.
+  const before = await page.getByTestId('player-x').innerText();
+  await page.keyboard.press('Space');
+  const after = await page.getByTestId('player-x').innerText();
+
+  expect(after).not.toBe(before); // dead behavior fails here → verifier finding: fail
+});

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -595,6 +595,7 @@ function runRuntimeChecks(options = {}) {
       finding = {
         severity: 'blocked',
         check_type: check.type,
+        required: Boolean(check.required),
         assertion: check.assertion || null,
         maker_claim: makerClaim,
         verifier_result: 'blocked',
@@ -608,6 +609,7 @@ function runRuntimeChecks(options = {}) {
       finding = {
         severity: failed ? (check.required ? 'critical' : 'warn') : 'info',
         check_type: check.type,
+        required: Boolean(check.required),
         assertion: check.assertion || null,
         maker_claim: makerClaim,
         verifier_result: outcome.result,
@@ -631,6 +633,86 @@ function runRuntimeChecks(options = {}) {
   };
 }
 
+// --- VERIFIER-RAIL-01 (issue #102): enforced runtime verifier stage ----------
+// Makes the verifier unavoidable for slices that need it — strict default with a
+// human-only escape hatch. Done is decided by the gate using verifier evidence:
+// maker_claim=complete with a required finding blocked/failed => gate blocks.
+
+const VERIFIER_REQUIRED_WHEN_DEFAULT = ['ui', 'workflow', 'api_behavior', 'integration', 'data_mutation', 'auth', 'billing', 'runtime_required'];
+const VERIFIER_VALUE_BEARING_TAGS = ['api_behavior', 'data_mutation', 'billing'];
+
+function verifierRequiredForSlice(sliceTags = [], options = {}) {
+  const mode = options.mode || 'auto';
+  if (mode === 'never') return false;
+  if (mode === 'always') return true;
+  const requiredWhen = options.requiredWhen || VERIFIER_REQUIRED_WHEN_DEFAULT;
+  const tags = Array.isArray(sliceTags) ? sliceTags : [];
+  return tags.some((t) => requiredWhen.includes(t));
+}
+
+function verifierGateDecision(findings = []) {
+  const required = findings.filter((f) => f.required);
+  if (!required.length) return 'blocked'; // required runtime evidence missing
+  if (required.some((f) => f.verifier_result === 'blocked')) return 'blocked';
+  if (required.some((f) => f.verifier_result === 'fail')) return 'fail';
+  return 'pass';
+}
+
+function runVerifierStage(options = {}) {
+  const paths = verificationPaths(options);
+  const sliceTags = Array.isArray(options.sliceTags) ? options.sliceTags : [];
+  const required = verifierRequiredForSlice(sliceTags, { mode: options.requiredMode, requiredWhen: options.requiredWhen });
+  const makerClaim = options.makerClaim || UNKNOWN;
+
+  // Human-only escape hatch — never silent.
+  if (options.humanSkip) {
+    const approvedBy = options.humanSkip.approved_by || options.humanSkip.approvedBy;
+    const reason = options.humanSkip.reason;
+    if (!approvedBy || !reason) throw new Error('verifier skip requires a human exception with approved_by and reason');
+    appendLedger(paths.ledgerPath, {
+      stage: 'verifier_stage', event: 'verifier_skip_override', required, slice_tags: sliceTags, approved_by: approvedBy, reason,
+    });
+    return { status: 'skipped_human_override', required, gate: 'skipped' };
+  }
+
+  if (!required) return { status: 'not_required', required: false, gate: 'not_applicable' };
+
+  if (makerClaim && makerClaim !== UNKNOWN) {
+    appendLedger(paths.ledgerPath, { stage: 'verifier_stage', event: 'maker_claim', claim: makerClaim });
+  }
+
+  const record = (gate, extra = {}) => appendLedger(paths.ledgerPath, {
+    stage: 'verifier_stage', event: 'verifier_stage', slice_tags: sliceTags,
+    maker_claim: makerClaim, verifier_result: gate, gate_result: gate === 'pass' ? 'pass' : 'blocked', ...extra,
+  });
+
+  const contractGate = requireAcceptedVerificationContract(options);
+  if (!contractGate.accepted) {
+    record('blocked', { reason: contractGate.reason });
+    return { status: 'blocked', required, gate: 'blocked', reason: contractGate.reason };
+  }
+
+  const checks = options.checks || (contractGate.contract && contractGate.contract.runtime_checks) || [];
+  const valueBearing = options.valueBearing !== undefined
+    ? options.valueBearing
+    : sliceTags.some((t) => VERIFIER_VALUE_BEARING_TAGS.includes(t));
+  const validation = validateRuntimeChecks(checks, { uiOrWorkflow: true, valueBearing });
+  if (!validation.ok) {
+    record('blocked', { reason: validation.errors.join('; ') });
+    return { status: 'blocked', required, gate: 'blocked', errors: validation.errors };
+  }
+
+  const { findings, summary } = runRuntimeChecks({
+    runDir: options.runDir, contract: options.contract, ledger: options.ledger, checks, makerClaim, runner: options.runner,
+  });
+  const gate = verifierGateDecision(findings);
+  record(gate, {
+    findings_count: findings.length,
+    divergence: makerClaim === 'complete' && gate !== 'pass' ? 'maker_claimed_complete_but_gate_blocked' : null,
+  });
+  return { status: gate === 'pass' ? 'passed' : 'blocked', required, gate, findings, summary };
+}
+
 // --- VERIFIER-TRACE-01 (epic #100): maker/verifier/gate divergence surface ----
 // A pure read over the run ledger (+ verifier-findings). Groups maker claim,
 // verifier finding, mechanical gate result, and disposition; flags divergence.
@@ -646,7 +728,7 @@ function verifierTrace(options = {}) {
   const maker = makerEntry
     ? {
       claim: makerEntry.claim || (makerEntry.stop_reason === 'gate_rerun_required' ? 'produced_output' : UNKNOWN),
-      claimed_done: Boolean(makerEntry.claim === 'done' || makerEntry.claimed_done),
+      claimed_done: Boolean(['done', 'complete'].includes(makerEntry.claim) || makerEntry.claimed_done),
       output_path: makerEntry.output_path || UNKNOWN,
       transcript_path: makerEntry.transcript_path || UNKNOWN,
     }
@@ -1221,6 +1303,29 @@ function runLoop(options) {
     return { ...adapterResult, contractPath, ledgerPath };
   }
 
+  // VERIFIER-RAIL-01 (#102): the verifier stage gates feature-build "done".
+  // Runs before the provenance gate for runtime-required slices; a blocked/failed
+  // verifier finding (or a missing accepted contract) blocks gate advancement.
+  if (contract.loop === 'feature-build' && contract.current_stage_or_rail === '6_provenance') {
+    const sliceTags = contract.slice_tags || [];
+    if (verifierRequiredForSlice(sliceTags, { mode: contract.verifier_required_mode })) {
+      const stage = runVerifierStage({
+        contract: contractPath,
+        ledger: ledgerPath,
+        sliceTags,
+        requiredMode: contract.verifier_required_mode,
+        makerClaim: contract.maker_claim || 'complete',
+        humanSkip: options.verifierHumanSkip || contract.verifier_human_skip,
+        runner: options.runtimeRunner,
+      });
+      if (stage.status !== 'passed' && stage.status !== 'skipped_human_override' && stage.status !== 'not_required') {
+        contract.terminal_status = 'blocked';
+        writeYaml(contractPath, { run_contract: contract });
+        return { status: 'blocked_verifier_stage', verifier_stage: stage, contractPath, ledgerPath };
+      }
+    }
+  }
+
   const registryResult = executeVerifierRegistry(contract, options);
   let promptPath = null;
   if (registryResult.status === 'agent_action_required') {
@@ -1331,6 +1436,8 @@ function isTerminalStatus(status) {
     'adapter_unavailable',
     'adapter_failed',
     'blocked_human_required',
+    'blocked_verification_required',
+    'blocked_verifier_stage',
     'dry_run',
   ].includes(status);
 }
@@ -1447,6 +1554,9 @@ module.exports = {
   assembleVerifierInput,
   validateRuntimeChecks,
   runRuntimeChecks,
+  verifierRequiredForSlice,
+  verifierGateDecision,
+  runVerifierStage,
   verifierTrace,
   readLedger,
   readLedgerTail,

--- a/tests/contracts/verifier-rail.test.js
+++ b/tests/contracts/verifier-rail.test.js
@@ -1,0 +1,143 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const {
+  runVerifierStage,
+  verifierRequiredForSlice,
+  verifierGateDecision,
+  runLoop,
+  verifierTrace,
+  verificationPaths,
+  writeVerificationProposal,
+  decideVerification,
+} = require('../../scripts/specflow-runner.cjs');
+
+// VERIFIER-RAIL-01 / J-VERIFIER-RAIL (issue #102)
+
+function tempRun() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-rail-'));
+}
+const PASS = 'node -e "process.exit(0)"';
+const FAIL = 'node -e "process.exit(1)"';
+
+function acceptContract(runDir, checks) {
+  writeVerificationProposal({ runDir, journeyId: 'J-VERIFIER-RAIL', makerPolicyId: 'm', verifierPolicyId: 'v', runtimeChecks: checks });
+  decideVerification({
+    runDir, decision: 'accept',
+    verificationContract: {
+      journey_id: 'J-VERIFIER-RAIL', maker_policy_id: 'm', verifier_policy_id: 'v',
+      runtime_checks: checks, forbidden_evidence: ['maker self-review'],
+    },
+  });
+}
+
+describe('VERIFIER-RAIL-01 — enforced runtime verifier stage (#102)', () => {
+  test('AC2/AC10: required-by-slice-type detection with escape modes', () => {
+    expect(verifierRequiredForSlice(['ui'])).toBe(true);
+    expect(verifierRequiredForSlice(['data_mutation'])).toBe(true);
+    expect(verifierRequiredForSlice(['docs'])).toBe(false);
+    expect(verifierRequiredForSlice(['docs'], { mode: 'always' })).toBe(true);
+    expect(verifierRequiredForSlice(['ui'], { mode: 'never' })).toBe(false);
+  });
+
+  test('AC4/AC5: gate decision blocks on missing/blocked/failed required findings', () => {
+    expect(verifierGateDecision([])).toBe('blocked');
+    expect(verifierGateDecision([{ required: true, verifier_result: 'blocked' }])).toBe('blocked');
+    expect(verifierGateDecision([{ required: true, verifier_result: 'fail' }])).toBe('fail');
+    expect(verifierGateDecision([{ required: true, verifier_result: 'pass' }])).toBe('pass');
+  });
+
+  test('AC10: doc-only slice is not required', () => {
+    expect(runVerifierStage({ runDir: tempRun(), sliceTags: ['docs'] }).status).toBe('not_required');
+  });
+
+  test('AC1/AC4: blocks when required but no accepted contract', () => {
+    const r = runVerifierStage({ runDir: tempRun(), sliceTags: ['ui'] });
+    expect(r.gate).toBe('blocked');
+    expect(r.reason).toMatch(/verification contract/);
+  });
+
+  test('AC2/AC3: runs checks and passes; findings written to verifier-findings.jsonl', () => {
+    const runDir = tempRun();
+    acceptContract(runDir, [{ type: 'api', command: PASS, assertion: 'reread', required: true }]);
+    const r = runVerifierStage({ runDir, sliceTags: ['api_behavior'], makerClaim: 'complete' });
+    expect(r.status).toBe('passed');
+    expect(fs.existsSync(verificationPaths({ runDir }).findingsPath)).toBe(true);
+  });
+
+  test('AC5: blocks when a required runtime check fails', () => {
+    const runDir = tempRun();
+    acceptContract(runDir, [{ type: 'playwright', command: FAIL, assertion: 'space moves player', required: true }]);
+    const r = runVerifierStage({ runDir, sliceTags: ['ui'], makerClaim: 'complete' });
+    expect(r.gate).toBe('fail');
+    expect(r.status).toBe('blocked');
+  });
+
+  test('AC6: screenshot-only cannot satisfy a value-bearing slice', () => {
+    const runDir = tempRun();
+    acceptContract(runDir, [{ type: 'screenshot', command: PASS, assertion: 'renders', required: true }]);
+    const r = runVerifierStage({ runDir, sliceTags: ['data_mutation'] });
+    expect(r.gate).toBe('blocked');
+    expect((r.errors || []).join()).toMatch(/screenshot-only/);
+  });
+
+  test('AC9: human-only override requires a reason and is ledgered', () => {
+    const runDir = tempRun();
+    expect(() => runVerifierStage({ runDir, sliceTags: ['ui'], humanSkip: { approved_by: 'colm' } })).toThrow();
+    const r = runVerifierStage({ runDir, sliceTags: ['ui'], humanSkip: { approved_by: 'colm', reason: 'infra outage' } });
+    expect(r.status).toBe('skipped_human_override');
+    expect(fs.readFileSync(verificationPaths({ runDir }).ledgerPath, 'utf8')).toMatch(/verifier_skip_override/);
+  });
+
+  test('AC8: the rail catches a real behavior bug (looks done, space does nothing)', () => {
+    const broken = tempRun();
+    acceptContract(broken, [{ type: 'playwright', command: 'BEHAVIOR_BUG=1 node examples/verifier-rail-proof/journey.js', assertion: 'space moves player', required: true }]);
+    expect(runVerifierStage({ runDir: broken, sliceTags: ['ui'], makerClaim: 'complete' }).status).toBe('blocked');
+
+    const fixed = tempRun();
+    acceptContract(fixed, [{ type: 'playwright', command: 'node examples/verifier-rail-proof/journey.js', assertion: 'space moves player', required: true }]);
+    expect(runVerifierStage({ runDir: fixed, sliceTags: ['ui'], makerClaim: 'complete' }).status).toBe('passed');
+  });
+
+  test('AC1/AC5/AC7: wired into runLoop — blocked_verifier_stage at 6_provenance + trace divergence', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-rail-loop-'));
+    const runDir = path.join(dir, '.specflow/runs/slice');
+    fs.mkdirSync(runDir, { recursive: true });
+    const contractPath = path.join(runDir, 'run-contract.yaml');
+    const ledgerPath = path.join(runDir, 'ledger.jsonl');
+    fs.writeFileSync(contractPath, yaml.dump({
+      run_contract: {
+        loop: 'feature-build', goal: 'g', input_artifact: 'x', path: 'templates/QA/loops/feature-build.yaml',
+        current_stage_or_rail: '6_provenance', next_gate: 'provenance', durable_evidence: [contractPath],
+        stop_condition: 'handoff', never_without_human: ['git push'],
+        slice_tags: ['ui'], maker_claim: 'complete',
+        storage: { contract_path: contractPath, ledger_path: ledgerPath },
+      },
+    }));
+    acceptContract(runDir, [{ type: 'playwright', command: FAIL, assertion: 'space moves player', required: true }]);
+
+    const res = runLoop({ slug: 'slice', contract: contractPath, ledger: ledgerPath });
+    expect(res.status).toBe('blocked_verifier_stage');
+    expect(verifierTrace({ runDir }).divergence).toContain('maker_claimed_done_but_verifier_failed');
+  });
+
+  test('AC10: runLoop backward-compatible — doc-only slice does not hit the verifier stage', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-rail-bc-'));
+    const runDir = path.join(dir, '.specflow/runs/slice');
+    fs.mkdirSync(runDir, { recursive: true });
+    const contractPath = path.join(runDir, 'run-contract.yaml');
+    const ledgerPath = path.join(runDir, 'ledger.jsonl');
+    fs.writeFileSync(contractPath, yaml.dump({
+      run_contract: {
+        loop: 'feature-build', goal: 'g', input_artifact: 'x', path: 'templates/QA/loops/feature-build.yaml',
+        current_stage_or_rail: '6_provenance', next_gate: 'provenance', durable_evidence: [contractPath],
+        stop_condition: 'handoff', never_without_human: ['git push'],
+        storage: { contract_path: contractPath, ledger_path: ledgerPath },
+      },
+    }));
+    const res = runLoop({ slug: 'slice', contract: contractPath, ledger: ledgerPath });
+    expect(res.status).not.toBe('blocked_verifier_stage');
+  });
+});


### PR DESCRIPTION
Closes #102. Builds on the epic #100 primitives (PR #101) to make the verifier **unavoidable** for slices that need it — closing the "runtime verification stays optional" failure mode.

**Rule:** done is decided by the gate, using verifier evidence. `maker_claim=complete` + a required verifier finding blocked/failed ⇒ gate returns `blocked`.

## Posture (strict default + human escape hatch)
Required-by-slice-type: `ui, workflow, api_behavior, integration, data_mutation, auth, billing, runtime_required` (modes `auto|always|never`). Skips are **human-only and ledgered**, never silent.

## Acceptance criteria
| AC | Covered by |
|----|-----------|
| AC1 accepted contract detected around maker stage | rail + runLoop wiring |
| AC2 runtime-required slices auto-run verifier | `verifierRequiredForSlice` / `runVerifierStage` |
| AC3 checks write `verifier-findings.jsonl` | `runRuntimeChecks` |
| AC4 missing required findings block | `verifierGateDecision` |
| AC5 failed/blocked findings block | `verifierGateDecision` + runLoop |
| AC6 screenshot-only insufficient for value-bearing | `validateRuntimeChecks` |
| AC7 trace shows maker vs verifier vs gate | `verifierTrace` divergence |
| AC8 Playwright journey proves a behavior bug is caught | `examples/verifier-rail-proof/` |
| AC9 human override ledgered, not silent | `verifier_skip_override` entry |
| AC10 non-runtime/doc slices backward-compatible | `not_required` path |

## Wiring
`runLoop` runs the verifier stage before the feature-build provenance gate for runtime-required slices; a block returns `blocked_verifier_stage` and never advances.

## Invariant added to README
> Frontier-model scaffolding is disposable. Gates, ledger, state, verifier evidence, and human boundaries are not.

## Verification
- 11 tests (all 10 ACs), behavior proof runs (fixed passes / bug fails).
- Full suite: **830/830 across 32 suites** (no regressions; baseline 819 from #101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)