### PR TITLE
feat: fable subordinate controls — routing-honesty/cost/vision/routine (#83 #87 #88 #89)

### DIFF
--- a/docs/specs/fable-subordinate-controls/contract.yml
+++ b/docs/specs/fable-subordinate-controls/contract.yml
@@ -1,0 +1,67 @@
+feature: fable-subordinate-controls
+requirements:
+  - id: REQ-ROUTING-HONESTY-01
+    statement: A silent model downgrade (effective differs from requested, no recorded reason) is a failed contract.
+  - id: REQ-COST-01
+    statement: Cost accounting reports per-gate cost and cost-per-accepted-change; missing usage is unknown, never fabricated.
+  - id: REQ-VISION-01
+    statement: A vision finding is evidence with gate_result pending and can never be a gate pass.
+  - id: REQ-ROUTINE-01
+    statement: A routine manifest must call specflow run, contain no auto human-gated action, and route proposals through spec-build.
+journeys:
+  - journey_meta:
+      id: J-MODEL-ROUTING-HONESTY
+      persona: cost_conscious_operator
+      owner_ticket: MODEL-ROUTING-HONESTY-01
+      assertion_bar: a downgrade without a recorded reason fails the contract
+    scenario: detect a silent model downgrade
+    given:
+      - an adapter policy requesting a specific model
+    when:
+      - the effective/reported model differs or a fallback is used
+    then:
+      - a downgrade without a recorded reason is a failed contract
+      - the requested and effective model and the reason are ledgered
+
+  - journey_meta:
+      id: J-COST-ACCOUNTING
+      persona: cost_conscious_operator
+      owner_ticket: COST-ACCOUNTING-01
+      assertion_bar: missing usage is unknown, never zero
+    scenario: summarize cost per accepted change
+    given:
+      - a ledger with adapter and gate entries, some without usage
+    when:
+      - cost accounting runs
+    then:
+      - per-gate cost, accepted gates, and cost-per-accepted-change are reported
+      - missing usage is counted as unknown, not fabricated as zero
+
+  - journey_meta:
+      id: J-VISION-EVIDENCE
+      persona: ui_reviewer
+      owner_ticket: VISION-EVIDENCE-01
+      assertion_bar: a vision verdict never advances a gate
+    scenario: record a vision finding as evidence only
+    given:
+      - a screenshot and a vision verdict for a goal
+    when:
+      - the vision finding is recorded
+    then:
+      - the finding carries gate_result pending and names goal/screenshot/model/verdict/gaps
+      - a vision verdict cannot be treated as a gate pass
+
+  - journey_meta:
+      id: J-ROUTINE-SAFETY
+      persona: platform_scheduler
+      owner_ticket: ROUTINE-SAFETY-01
+      assertion_bar: an unsafe routine manifest is rejected
+    scenario: validate a scheduled routine manifest
+    given:
+      - a routine manifest with a command, trigger, and policy
+    when:
+      - the manifest is validated
+    then:
+      - a command that does not call specflow run is rejected
+      - an auto human-gated action is rejected
+      - portfolio proposals must declare a spec-build proposal policy

--- a/docs/specs/fable-subordinate-controls/falsification.md
+++ b/docs/specs/fable-subordinate-controls/falsification.md
@@ -1,0 +1,70 @@
+# Fable Subordinate Controls — Falsification
+
+**Date:** 2026-07-02
+**Reviewed PRD:** `docs/specs/fable-subordinate-controls/prd.md`
+PRD SHA-256: ac4030ed30481f3b801248baa94555368f7006700436cb7b1e0f539d5afe5f42
+
+## Premise Attack
+
+| Claim | Attack | Result |
+|---|---|---|
+| These controls matter. | They are subordinate plumbing, not the trust boundary. | Holds with scope: thin and disposable, subordinate to the verifier/gate core. |
+| Honesty about downgrade helps. | A downgrade with a reason is still a downgrade. | Holds: the reason makes it honest evidence; silent downgrade is the failure. |
+| Cost accounting is safe. | Cost could be fabricated when usage is missing. | Holds only because missing usage is recorded as unknown, never zero. |
+| Vision is useful evidence. | Vision could be used as a verdict. | Holds only because gate_result stays pending and vision cannot pass a gate. |
+
+## Claim Inventory
+
+| Claim | Source | Verification route |
+|---|---|---|
+| Silent downgrade is a failed contract. | #83 and fable-enable.md | assertModelHonesty + hostile fixture. |
+| Missing usage is unknown. | #89 | costAccounting + test with missing usage. |
+| Vision is evidence only. | #88 | visionFinding gate_result pending + refusal helper. |
+| Routines must call specflow run. | #87 | validateRoutineManifest + hostile fixture. |
+
+## Dependency Audit
+
+| Dependency | Risk | Disposition |
+|---|---|---|
+| `normalizeAdapterPolicy` | Already carries requested/effective/fallback. | Honesty ticket adds the enforcement check. |
+| `summarizeLedger` | Cost fields may be absent. | Cost ticket treats absence as unknown. |
+| `scripts/teardown-gate.cjs` | Vision evidence path exists but unenforced. | Vision ticket keeps verdict pending. |
+| `scaffoldRoutineManifest` | Manifests could bypass specflow run. | Routine ticket validates manifests. |
+
+## Acceptance Gate Attack
+
+| Acceptance | Attack | Required guard |
+|---|---|---|
+| Downgrade honesty. | Downgrade recorded but not flagged. | Missing reason fails the contract. |
+| Cost accounting. | Missing usage counted as zero. | Missing usage is unknown. |
+| Vision evidence. | Vision verdict advances a gate. | gate_result pending; refusal helper. |
+| Routine safety. | Manifest runs git push directly. | Reject non-specflow-run and human-gated actions. |
+
+## Source / Reality Ledger
+
+| Source claim | Reality check | Status |
+|---|---|---|
+| Adapter policy has model routing fields. | `normalizeAdapterPolicy` returns requested/effective/fallback. | PASS |
+| Ledger summary exists. | `summarizeLedger` exists. | PASS |
+| Routine manifest scaffolding exists. | `scaffoldRoutineManifest` exists. | PASS |
+| Enforcement already exists. | No honesty/cost/vision/routine enforcement yet. | GAP OWNED |
+
+## Overclaim / Scope Leakage
+
+| Overclaim | Correction | Owner |
+|---|---|---|
+| "Routing/cost is the product." | Subordinate plumbing; verifier/gate is the product. | PRD non-goal |
+| "Vision proves UI correctness." | Vision is evidence; behavior journeys prove value. | VISION-EVIDENCE-01 |
+| "Routines can act autonomously." | Human-gated actions stay blocked; proposals enter spec-build. | ROUTINE-SAFETY-01 |
+
+## Banned-Mode Self-Check
+
+| Banned mode | Present? | Note |
+|---|---|---|
+| Stub sections | No | Real attacks per section. |
+| Scope creep | No | Limited to #83/#87/#88/#89 enforcement. |
+| Overclaim | No | Controls stay subordinate to the gate. |
+
+## Final Verdict
+
+PASS WITH STIPULATIONS — proceed to Gate B. Stipulation: all four controls remain subordinate to the mechanical gate and human boundaries and must never advance a gate on their own.

--- a/docs/specs/fable-subordinate-controls/issues.json
+++ b/docs/specs/fable-subordinate-controls/issues.json
@@ -1,0 +1,6 @@
+[
+  { "number": 83, "title": "[SPECFLOW] MODEL-ROUTING-01", "body": "Journey IDs: J-MODEL-ROUTING-HONESTY\n\nLocal child ticket: MODEL-ROUTING-HONESTY-01. See docs/specs/fable-subordinate-controls/tickets.md." },
+  { "number": 89, "title": "[SPECFLOW] COST-01", "body": "Journey IDs: J-COST-ACCOUNTING\n\nLocal child ticket: COST-ACCOUNTING-01. See docs/specs/fable-subordinate-controls/tickets.md." },
+  { "number": 88, "title": "[SPECFLOW] VISION-GATE-01", "body": "Journey IDs: J-VISION-EVIDENCE\n\nLocal child ticket: VISION-EVIDENCE-01. See docs/specs/fable-subordinate-controls/tickets.md." },
+  { "number": 87, "title": "[SPECFLOW] ROUTINE-01", "body": "Journey IDs: J-ROUTINE-SAFETY\n\nLocal child ticket: ROUTINE-SAFETY-01. See docs/specs/fable-subordinate-controls/tickets.md." }
+]

--- a/docs/specs/fable-subordinate-controls/prd.md
+++ b/docs/specs/fable-subordinate-controls/prd.md
@@ -1,0 +1,34 @@
+# Fable Subordinate Controls PRD
+
+**Date:** 2026-07-02
+**Loop:** spec-build
+**Slug:** `fable-subordinate-controls`
+**Parent tickets:** #83 (MODEL-ROUTING), #89 (COST), #88 (VISION-GATE), #87 (ROUTINE)
+**Goal:** Land the subordinate Fable-era controls as thin, enforced, disposable primitives — subordinate to the trust core (verifier rail, state, worktree already shipped).
+
+## Problem
+
+After the verifier rail (#102/#103), four lower-priority controls remain. Per `docs/specs/fable-enable.md` they are plumbing, not the trust boundary — so they must be **thin and enforce their one honesty rule**, never expand scope or become the product:
+
+1. **Silent model downgrade.** A run may request one model and receive another (fallback/refusal). A silent downgrade is dishonest evidence.
+2. **Fabricated cost.** Missing usage metadata must be recorded as unknown, not treated as zero.
+3. **Vision-as-verdict.** A screenshot/vision verdict is evidence, never a gate pass.
+4. **Unsafe routines.** Scheduled routines must call `specflow run`, preserve human gates, and route portfolio proposals through spec-build.
+
+## Requirements
+
+- `REQ-ROUTING-HONESTY-01` (MUST): An effective model that differs from the requested model (or a fallback) without a recorded reason is a failed contract, recorded in the ledger.
+- `REQ-COST-01` (MUST): Cost accounting reports per-gate cost, accepted gates, and cost-per-accepted-change; missing usage is `unknown`, never fabricated as zero.
+- `REQ-VISION-01` (MUST): A vision finding carries `gate_result: pending`; a vision verdict can never be treated as a gate pass.
+- `REQ-ROUTINE-01` (MUST): A routine manifest is rejected unless its command calls `specflow run`, it contains no auto human-gated action, and portfolio proposals declare a spec-build proposal policy.
+
+## Non-Goals
+
+- Making model routing, cost, vision, or scheduling the product. They are subordinate to the verifier/gate trust core.
+- Any provider-specific pricing or safety claim beyond what the run reports.
+- Hosted/background scheduling in the local runner (manifests only).
+
+## Success Criteria
+
+- Each control has a small enforced primitive with a hostile fixture and full test coverage.
+- None weakens the mechanical gate or the human-boundary rules.

--- a/docs/specs/fable-subordinate-controls/tickets.json
+++ b/docs/specs/fable-subordinate-controls/tickets.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "MODEL-ROUTING-HONESTY-01",
+    "title": "A silent model downgrade is a failed contract",
+    "writes": ["ledger.jsonl"],
+    "reads": ["normalizeAdapterPolicy", "adapter_policy", "ledger.jsonl"],
+    "adrNone": "No ADR directory; reuse declared against the adapter policy and ledger surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs"],
+    "journeys": ["J-MODEL-ROUTING-HONESTY"]
+  },
+  {
+    "id": "COST-ACCOUNTING-01",
+    "title": "Report cost per accepted change; missing usage is unknown",
+    "writes": ["runStatus", "ledger.jsonl"],
+    "reads": ["ledger.jsonl", "summarizeLedger"],
+    "adrNone": "No ADR directory; reuse declared against the ledger summary and status surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs"],
+    "journeys": ["J-COST-ACCOUNTING"]
+  },
+  {
+    "id": "VISION-EVIDENCE-01",
+    "title": "Vision finding is evidence only, never a gate pass",
+    "writes": ["ledger.jsonl"],
+    "reads": ["teardown-gate", "ledger.jsonl"],
+    "adrNone": "No ADR directory; reuse declared against teardown evidence and ledger surfaces.",
+    "reuses": ["scripts/specflow-runner.cjs", "scripts/teardown-gate.cjs"],
+    "journeys": ["J-VISION-EVIDENCE"]
+  },
+  {
+    "id": "ROUTINE-SAFETY-01",
+    "title": "Reject routine manifests that bypass specflow run or human gates",
+    "writes": ["scaffoldRoutineManifest"],
+    "reads": ["scaffoldRoutineManifest", "never_without_human"],
+    "adrNone": "No ADR directory; reuse declared against the routine manifest surface.",
+    "reuses": ["scripts/specflow-runner.cjs"],
+    "journeys": ["J-ROUTINE-SAFETY"]
+  }
+]

--- a/docs/specs/fable-subordinate-controls/tickets.md
+++ b/docs/specs/fable-subordinate-controls/tickets.md
@@ -1,0 +1,45 @@
+# Fable Subordinate Controls Ticket Packet
+
+**Source tickets:** #83 (MODEL-ROUTING), #89 (COST), #88 (VISION-GATE), #87 (ROUTINE)
+**Loop:** spec-build
+
+## Scope
+
+Thin, enforced, disposable controls subordinate to the verifier/gate trust core. Same pattern as #101/#103: small enforced primitive, hostile fixture, full test coverage. None weakens the mechanical gate or human boundaries.
+
+## Tickets
+
+### MODEL-ROUTING-HONESTY-01 — A silent model downgrade is a failed contract
+
+**Journey:** `J-MODEL-ROUTING-HONESTY`
+
+Acceptance:
+- Given a requested model, an effective/reported model that differs (or a fallback) without a recorded reason fails the contract.
+- Requested model, effective model, and reason (or its absence) are recorded in the ledger.
+- A recorded fallback/refusal reason makes the downgrade an honest, passing record.
+
+### COST-ACCOUNTING-01 — Report cost per accepted change; missing usage is unknown
+
+**Journey:** `J-COST-ACCOUNTING`
+
+Acceptance:
+- Cost accounting reports total cost, per-gate cost, accepted gates, and cost-per-accepted-change.
+- Missing usage metadata is counted as `unknown`, never fabricated as zero.
+- Exposed via `specflow run status`.
+
+### VISION-EVIDENCE-01 — Vision finding is evidence only, never a gate pass
+
+**Journey:** `J-VISION-EVIDENCE`
+
+Acceptance:
+- A vision finding names goal, screenshot, model/provider, verdict, and gaps, and carries `gate_result: pending`.
+- A helper refuses to treat a vision verdict as a gate pass.
+
+### ROUTINE-SAFETY-01 — Reject routine manifests that bypass specflow run or human gates
+
+**Journey:** `J-ROUTINE-SAFETY`
+
+Acceptance:
+- A routine manifest whose command does not call `specflow run` is rejected.
+- A manifest containing an auto human-gated action (push/PR/merge/--no-verify/override) is rejected.
+- Portfolio-improvement routines must declare a spec-build proposal policy.

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -715,6 +715,109 @@ function runRuntimeChecks(options = {}) {
   };
 }
 
+// --- Fable subordinate controls (thin, subordinate to the mechanical gate) ----
+
+// MODEL-ROUTING-HONESTY-01 (#83): a silent downgrade is a failed contract.
+function assertModelHonesty(info = {}) {
+  const requested = info.requested_model || info.model || null;
+  const effective = info.effective_model || null;
+  const fallback = info.fallback_model || null;
+  const reason = info.fallback_refusal_reason || info.reason || null;
+  const known = Boolean(effective && effective !== UNKNOWN);
+  const downgrade = Boolean(known && ((requested && effective !== requested) || (fallback && effective === fallback)));
+  if (downgrade && !reason) {
+    return {
+      ok: false, downgrade: true, requested_model: requested, effective_model: effective, reason: null,
+      violation: 'silent model downgrade: effective model differs from requested with no recorded reason',
+    };
+  }
+  return { ok: true, downgrade, requested_model: requested, effective_model: effective, reason };
+}
+
+function recordModelHonesty(ledgerPath, info = {}) {
+  const result = assertModelHonesty(info);
+  appendLedger(ledgerPath, {
+    stage: 'routing', event: 'model_honesty',
+    requested_model: result.requested_model, effective_model: result.effective_model,
+    downgrade: result.downgrade, reason: result.reason || null,
+    result: result.ok ? 'ok' : 'failed_contract',
+  });
+  return result;
+}
+
+// COST-ACCOUNTING-01 (#89): cost per accepted change; missing usage is unknown.
+function costAccounting(entries = []) {
+  const rows = [];
+  let total = 0;
+  let unknownUsage = 0;
+  let acceptedGates = 0;
+  for (const e of entries) {
+    if (e.result === 'pass') acceptedGates += 1;
+    const isWork = Boolean(e.provider) || e.event === 'adapter' || typeof e.estimated_cost === 'number';
+    if (!isWork) continue;
+    const model = e.effective_model || e.requested_model || UNKNOWN;
+    if (typeof e.estimated_cost === 'number') {
+      total += e.estimated_cost;
+      rows.push({ stage: e.stage || null, model, cost: e.estimated_cost });
+    } else {
+      unknownUsage += 1;
+      rows.push({ stage: e.stage || null, model, cost: 'unknown' }); // never fabricated as zero
+    }
+  }
+  return {
+    total_cost: total,
+    per_gate: rows,
+    accepted_gates: acceptedGates,
+    unknown_usage: unknownUsage,
+    cost_per_accepted_change: acceptedGates > 0 ? total / acceptedGates : null,
+  };
+}
+
+// VISION-EVIDENCE-01 (#88): a vision finding is evidence, never a gate pass.
+function visionFinding(info = {}) {
+  return {
+    stage: 'vision', event: 'vision_finding',
+    goal: info.goal || UNKNOWN,
+    screenshot: info.screenshot || null,
+    model: info.model || info.provider || UNKNOWN,
+    verdict: info.verdict || UNKNOWN,
+    gaps: Array.isArray(info.gaps) ? info.gaps : (info.gaps ? [info.gaps] : []),
+    gate_result: 'pending', // evidence only — the mechanical gate still decides
+  };
+}
+
+function recordVisionFinding(ledgerPath, info = {}) {
+  const finding = visionFinding(info);
+  appendLedger(ledgerPath, finding);
+  return finding;
+}
+
+function assertVisionNotGate(finding = {}) {
+  if (finding.gate_result && finding.gate_result !== 'pending') {
+    throw new Error('vision finding must not carry a gate result; it is evidence only');
+  }
+  return { gate_pass: false, reason: 'vision verdict is evidence, not a gate pass' };
+}
+
+// ROUTINE-SAFETY-01 (#87): reject manifests that bypass specflow run or human gates.
+const ROUTINE_HUMAN_GATED = ['git push', 'open pr', 'gh pr create', 'gh pr merge', ' merge ', '--no-verify', 'override contract'];
+function validateRoutineManifest(manifest = {}) {
+  const r = manifest.routine || manifest;
+  const errors = [];
+  const command = String(r.command || '');
+  if (!/specflow\s+run\b/.test(command)) errors.push('routine command must call `specflow run`');
+  const lower = ` ${command.toLowerCase()} `;
+  for (const act of ROUTINE_HUMAN_GATED) {
+    if (lower.includes(act)) errors.push(`routine command contains an auto human-gated action: ${act.trim()}`);
+  }
+  const label = `${r.slug || ''} ${r.loop || ''} ${r.kind || ''} ${r.trigger || ''}`;
+  const isPortfolio = /portfolio|improve|proposal/i.test(label);
+  if (isPortfolio && !r.proposal_policy) {
+    errors.push('portfolio-improvement routine must declare a proposal_policy (enter spec-build before implementation)');
+  }
+  return { ok: errors.length === 0, errors };
+}
+
 // --- VERIFIER-RAIL-01 (issue #102): enforced runtime verifier stage ----------
 // Makes the verifier unavoidable for slices that need it — strict default with a
 // human-only escape hatch. Done is decided by the gate using verifier evidence:
@@ -1528,6 +1631,7 @@ function runStatus(options = {}) {
     ledger_tail: readLedgerTail(ledgerPath, Number(options.limit || 10)),
     verifier_trace: verifierTrace({ contract: contractPath, ledger: ledgerPath }),
     reentry: reentryBriefing({ contract: contractPath, ledger: ledgerPath }),
+    cost: costAccounting(readLedger(ledgerPath)),
   };
 }
 
@@ -1664,6 +1768,13 @@ module.exports = {
   verifierRequiredForSlice,
   verifierGateDecision,
   runVerifierStage,
+  assertModelHonesty,
+  recordModelHonesty,
+  costAccounting,
+  visionFinding,
+  recordVisionFinding,
+  assertVisionNotGate,
+  validateRoutineManifest,
   verifierTrace,
   readLedger,
   readLedgerTail,

--- a/tests/contracts/fable-subordinate-controls.test.js
+++ b/tests/contracts/fable-subordinate-controls.test.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  assertModelHonesty,
+  recordModelHonesty,
+  costAccounting,
+  visionFinding,
+  assertVisionNotGate,
+  validateRoutineManifest,
+  scaffoldRoutineManifest,
+} = require('../../scripts/specflow-runner.cjs');
+
+function tmpLedger() {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-sub-')), 'ledger.jsonl');
+}
+function events(file) {
+  return fs.existsSync(file) ? fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : [];
+}
+
+describe('MODEL-ROUTING-HONESTY-01 — silent downgrade is a failed contract (#83)', () => {
+  test('HOSTILE: requested != effective with no reason fails the contract', () => {
+    const r = assertModelHonesty({ requested_model: 'fable', effective_model: 'opus' });
+    expect(r.ok).toBe(false);
+    expect(r.downgrade).toBe(true);
+    expect(r.violation).toMatch(/silent model downgrade/);
+  });
+  test('a recorded reason makes the downgrade honest, and it is ledgered', () => {
+    const ledger = tmpLedger();
+    const r = recordModelHonesty(ledger, { requested_model: 'fable', effective_model: 'opus', fallback_refusal_reason: 'safety route to opus' });
+    expect(r.ok).toBe(true);
+    const e = events(ledger).find((x) => x.event === 'model_honesty');
+    expect(e.result).toBe('ok');
+    expect(e.effective_model).toBe('opus');
+  });
+  test('an unreported effective model is not a downgrade (unknown != downgrade)', () => {
+    expect(assertModelHonesty({ requested_model: 'fable', effective_model: 'unknown' }).ok).toBe(true);
+  });
+});
+
+describe('COST-ACCOUNTING-01 — cost per accepted change; missing usage is unknown (#89)', () => {
+  test('HOSTILE: missing usage is counted as unknown, never fabricated as zero', () => {
+    const acct = costAccounting([
+      { provider: 'claude-print', stage: '5_impl', estimated_cost: 0.5, effective_model: 'sonnet' },
+      { provider: 'codex-exec', stage: '6_provenance' }, // no usage metadata
+      { result: 'pass', stage: '6_provenance' },
+    ]);
+    expect(acct.total_cost).toBe(0.5);
+    expect(acct.unknown_usage).toBe(1);
+    expect(acct.per_gate.some((r) => r.cost === 'unknown')).toBe(true);
+    expect(acct.accepted_gates).toBe(1);
+    expect(acct.cost_per_accepted_change).toBe(0.5);
+  });
+});
+
+describe('VISION-EVIDENCE-01 — vision is evidence, never a gate pass (#88)', () => {
+  test('a vision finding names goal/screenshot/model/verdict/gaps and stays pending', () => {
+    const f = visionFinding({ goal: 'cart totals', screenshot: 'a.png', model: 'fable-vision', verdict: 'looks correct', gaps: ['no reread'] });
+    expect(f.gate_result).toBe('pending');
+    expect(f.goal).toBe('cart totals');
+    expect(f.gaps).toEqual(['no reread']);
+  });
+  test('HOSTILE: a vision verdict cannot be treated as a gate pass', () => {
+    expect(assertVisionNotGate(visionFinding({ verdict: 'pass' })).gate_pass).toBe(false);
+    expect(() => assertVisionNotGate({ gate_result: 'pass' })).toThrow(/evidence only/);
+  });
+});
+
+describe('ROUTINE-SAFETY-01 — reject unsafe routine manifests (#87)', () => {
+  test('a scaffolded manifest that calls specflow run is accepted', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'specflow-routine-'));
+    const { manifest } = scaffoldRoutineManifest({ slug: 'nightly', outPath: path.join(dir, 'r.yml') });
+    expect(validateRoutineManifest(manifest).ok).toBe(true);
+  });
+  test('HOSTILE: a manifest that does not call specflow run / runs a human-gated action is rejected', () => {
+    const bad = validateRoutineManifest({ routine: { slug: 'x', command: 'git push origin main' } });
+    expect(bad.ok).toBe(false);
+    expect(bad.errors.join()).toMatch(/specflow run/);
+    expect(bad.errors.join()).toMatch(/human-gated/);
+  });
+  test('portfolio-improvement routine must declare a proposal policy', () => {
+    const r = validateRoutineManifest({ routine: { slug: 'portfolio-improve', command: 'npx specflow run spec-build --slug x' } });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join()).toMatch(/proposal_policy/);
+  });
+});


### PR DESCRIPTION
Runs the remaining subordinate Fable-era controls through **spec-build → feature-build** (packet `docs/specs/fable-subordinate-controls/`, GATE_A + GATE_B green). Thin, enforced, disposable — subordinate to the verifier/gate trust core, per `docs/specs/fable-enable.md`.

| Ticket | Enforced rule | Hostile fixture |
|---|---|---|
| **MODEL-ROUTING-HONESTY-01** (#83) | effective != requested with no reason ⇒ failed contract | silent downgrade fable→opus fails |
| **COST-ACCOUNTING-01** (#89) | per-gate cost + cost-per-accepted-change; missing usage = unknown | missing usage counted unknown, not zero |
| **VISION-EVIDENCE-01** (#88) | vision finding `gate_result: pending`; never a gate pass | a vision verdict cannot pass a gate |
| **ROUTINE-SAFETY-01** (#87) | manifest must call `specflow run`, no auto human-gated action, proposals via spec-build | `git push` manifest rejected |

`costAccounting` surfaced in `specflow run status`. None weakens the mechanical gate or human boundaries.

Verification: 9 new tests (4 hostile fixtures); full suite **847/847 across 35 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)