### PR TITLE
[codex] Add model routing confirmation docs

### DIFF
--- a/MODEL_ROUTING.md
+++ b/MODEL_ROUTING.md
@@ -1,0 +1,273 @@
+# Specflow Model Routing
+
+Specflow model routing lets a project choose which local agent runtime handles
+each stage of a larger initiative. The default pattern is:
+
+- expensive thinking and review: Claude/Fable through `claude -p`
+- bounded coding, tests, and release prep: Codex CLI through `codex exec`
+- thinking level: the policy `effort` field, recorded per route
+- approval: Specflow gates, CI, and humans
+
+Models do work. Models do not approve their own work.
+
+## Quick Start
+
+After `specflow init`, install the large-initiative routing default:
+
+```bash
+cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml
+```
+
+Start a loop normally:
+
+```bash
+specflow run spec-build --slug auth-system --goal "build auth" --input docs/auth-idea.md
+```
+
+If routing is active, Specflow stops before provider spend and prints the selected
+provider, role, requested model, fallback model, thinking level, budget,
+transcript path, and output path. Continue only after reviewing the choices:
+
+```bash
+specflow run spec-build --slug auth-system --confirm-models
+```
+
+If routing is not installed, Specflow reports that model routing is inactive and
+prints the setup command above. Agents using the Specflow skill must announce
+either `Model routing active:` or the setup instruction before starting
+`spec-build` or `feature-build`.
+
+## What The Default Does
+
+The template at `.specflow/adapter-policies/claude-code-large-routing.yml`
+defines three policies:
+
+| Policy | Runtime | Role | Default model | Thinking level | Fallback | Used for |
+|---|---|---|---|---|---|---|
+| `fable-planner` | `claude -p` | `planner` | `fable-5` | `xhigh` | `opus-4.8` | discovery and PRD shaping |
+| `fable-reviewer` | `claude -p` | `verifier` | `fable-5` | `xhigh` | `opus-4.8` | adversarial review and high-value review |
+| `gpt55-coder` | `codex exec` | `implementer` | `gpt-5.5` | `medium` | none | contracts, E2E, oracle wiring, implementation |
+
+The default route map is:
+
+```yaml
+routes:
+  spec-build:
+    discover: fable-planner
+    draft: fable-planner
+    adversary: fable-reviewer
+    tickets: gpt55-coder
+
+  feature-build:
+    2_contract: gpt55-coder
+    3_e2e: gpt55-coder
+    4_oracle: gpt55-coder
+    5_impl: gpt55-coder
+    review: fable-reviewer
+```
+
+The exact file uses expanded YAML objects so each route can carry a reason and
+each policy can carry tool permissions, budgets, transcript paths, and human
+boundaries.
+
+## Thinking Level
+
+Model routing includes both the model and how hard it should think. In adapter
+policies this is the `effort` field:
+
+```yaml
+adapter_policy:
+  requested_model: fable-5
+  role: planner
+  effort: xhigh
+```
+
+Specflow currently accepts these effort values:
+
+| Effort | Intended use |
+|---|---|
+| `low` | cheap, bounded chores where mistakes are easy to catch |
+| `medium` | normal coding, contract expansion, test writing |
+| `high` | hard implementation, debugging, or local design choices |
+| `xhigh` | expensive planning, adversarial review, architecture, falsification |
+| `ultracode` | provider-specific maximum coding/reasoning mode, only when supported |
+
+Effort is policy metadata, not a gate. A high-effort model output still has to
+pass Specflow gates, CI, and any human approvals. Provider effort labels can
+change over time, so keep them thin and easy to edit.
+
+## Why Confirmation Is Mandatory
+
+Fable/frontier routes are expensive and easy to trigger accidentally in a resumed
+automation. Specflow therefore treats routed provider execution as a human
+spend decision:
+
+1. Resolve the current loop stage from the durable run contract.
+2. Look up the matching route in `.specflow/adapter-routing.yml`.
+3. Print the selected provider/model plan.
+4. Stop with `model_confirmation_required`.
+5. Run the provider only when the operator reruns with `--confirm-models`.
+
+That confirmation does not approve the work product. It only approves spending
+the selected model on the current stage. The owning Specflow gate must still
+rerun before the loop advances.
+
+## How It Works Technically
+
+`specflow run` reads the durable run contract from:
+
+```text
+.specflow/runs/<slug>/run-contract.yaml
+```
+
+The current stage is stored as `current_stage_or_rail`. When no explicit
+`--adapter-policy` is passed, the runner searches for:
+
+```text
+.specflow/adapter-routing.yml
+.specflow/adapter-routing.yaml
+.specflow/adapter-routing.json
+```
+
+It supports either dotted route keys:
+
+```yaml
+routes:
+  spec-build.discover:
+    policy: fable-planner
+```
+
+or nested route keys:
+
+```yaml
+routes:
+  spec-build:
+    discover:
+      policy: fable-planner
+```
+
+The selected policy is normalized like any other adapter policy. The runner then
+records routing metadata in the JSONL ledger:
+
+```json
+{
+  "event": "model_confirmation",
+  "stop_reason": "model_confirmation_required",
+  "provider": "claude-print",
+  "role": "planner",
+  "effort": "xhigh",
+  "requested_model": "fable-5",
+  "fallback_model": "opus-4.8",
+  "max_budget_usd": 20
+}
+```
+
+After `--confirm-models`, adapter execution records the policy id, routing path,
+role, effort, requested model, effective model when reported by the provider,
+transcript path, output path, and whether the gate must rerun.
+
+## Changing The Defaults
+
+Edit:
+
+```text
+.specflow/adapter-routing.yml
+```
+
+To use Opus as the primary reviewer instead of Fable, change the reviewer policy:
+
+```yaml
+policies:
+  fable-reviewer:
+    adapter_policy:
+      requested_model: opus-4.8
+      model: opus-4.8
+      effort: high
+      fallback_model: null
+      max_budget_usd: 8
+```
+
+To lower planning spend, keep Fable but reduce the thinking level:
+
+```yaml
+policies:
+  fable-planner:
+    adapter_policy:
+      requested_model: fable-5
+      model: fable-5
+      effort: high
+      max_budget_usd: 12
+```
+
+To make Codex use a different model for implementation:
+
+```yaml
+policies:
+  gpt55-coder:
+    adapter_policy:
+      requested_model: gpt-5.5
+      model: gpt-5.5
+      effort: medium
+```
+
+To add a route for a new stage:
+
+```yaml
+routes:
+  feature-build:
+    6_provenance:
+      policy: gpt55-coder
+      reason: provenance evidence assembly
+```
+
+To disable automatic routing for a stage:
+
+```yaml
+routes:
+  spec-build:
+    tickets:
+      policy: none
+```
+
+To make a low-cost stage run without confirmation, override that route only:
+
+```yaml
+routes:
+  spec-build:
+    tickets:
+      policy: gpt55-coder
+      confirm_models: false
+```
+
+Keep confirmation enabled for expensive planning/review routes unless you have a
+separate budget control outside Specflow.
+
+## Claude Code And Codex
+
+Model routing is runtime-agnostic. The file decides which provider command is
+called.
+
+If you are in Claude Code and the default routing file is installed:
+
+- planning/review routes call `claude -p`
+- coding routes call `codex exec`
+
+If you are in Codex with the same file installed:
+
+- planning/review routes still call `claude -p`, so the Claude CLI must be
+  installed and authenticated
+- coding routes call `codex exec`
+
+For an OpenAI-only setup, create a separate routing file that points planning,
+review, and implementation policies at `codex-exec` with the OpenAI models and
+effort levels you want.
+
+## Safety Rules
+
+- Do not put subscription secrets in adapter routing files.
+- Do not grant push, merge, production deploy, `--no-verify`, or contract
+  override permissions to model policies.
+- Treat direct `--adapter-policy <path>` as a one-off override and announce the
+  selected provider/model before invoking it.
+- Do not treat provider output as a gate result. Provider output is work product;
+  Specflow gates, CI, and human sign-offs decide whether work advances.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Those CLIs keep their own authentication and subscriptions; Specflow stores no
 Claude/Codex subscription secrets. Provider output is never itself a gate result:
 the owning Specflow verifier must rerun before the run contract advances.
 
+For larger initiatives, use `.specflow/adapter-routing.yml` to declare the
+default split: expensive requirements/planning/review stages can route to a
+frontier Claude/Fable policy, while bounded coding/test/release-prep stages can
+route to Codex CLI with GPT-5.5. Each policy also declares a thinking level
+(`effort`) such as `medium`, `high`, or `xhigh`. The shipped
+`.specflow/adapter-policies/claude-code-large-routing.yml` template requires
+`--confirm-models` before invoking a routed provider, so expensive model choices
+are shown to the operator before spend.
+
+Before any build loop starts, the agent should say either `Model routing active:`
+with the current stage's provider/model choices, or explain how to install the
+routing file. No routed model spend should happen before that confirmation.
+
+See [Specflow Model Routing](MODEL_ROUTING.md) for the operator workflow, the
+technical routing format, and how to change the defaults.
+
 ### The three loops (`QA/loops/`)
 
 | Loop | For | In one line |

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,9 @@ When this skill is active, Claude Code MUST:
 4. **When a contract violation is reported**: Read the contract rule, understand why it exists, fix the code to comply. Never work around the test.
 5. **Never modify `non_negotiable` rules** unless the user explicitly says `override_contract: <contract_id>`.
 6. **Before accepting a ticket as specflow-compliant**: Pre-flight must have run and returned `passed`, `passed_with_warnings`, or a human-acknowledged `override:*` status. A ticket with `blocked`, `stale`, or missing pre-flight section is NOT compliant.
+7. **Before starting spec-build or feature-build work**: Confirm model routing in plain language. If `.specflow/adapter-routing.yml` exists, say `Model routing active:` and list the selected model/policy for the current stage before invoking it. If it does not exist, stop and give the setup command:
+   `cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml`.
+   Expensive/default routed adapters must not run until the user has confirmed the displayed model choices.
 
 ---
 

--- a/bin/specflow.js
+++ b/bin/specflow.js
@@ -135,7 +135,7 @@ const COMMANDS = {
     },
   },
   run: {
-    usage: 'specflow run <loop> [--slug <slug>] [--goal <goal>] [--input <path>] [--adapter-policy <path>]',
+    usage: 'specflow run <loop> [--slug <slug>] [--goal <goal>] [--input <path>] [--adapter-routing <path>]',
     desc: 'Run or resume a local contracted Specflow loop',
     run: (args) => {
       const code = runSpecflowLoop(args);
@@ -268,6 +268,7 @@ if (!command || command === 'help' || command === '--help' || command === '-h') 
   console.log('  npx @colmbyrne/specflow verify');
   console.log('  npx @colmbyrne/specflow audit 500');
   console.log('  npx @colmbyrne/specflow run spec-build --slug my-feature --goal "ready tickets" --input docs/idea.md');
+  console.log('  npx @colmbyrne/specflow run spec-build --slug my-feature --adapter-routing .specflow/adapter-routing.yml --confirm-models');
   console.log('  npx @colmbyrne/specflow provenance evidence/provenance-77-78-80.json --git-diff');
   console.log('  npx @colmbyrne/specflow adapter-smoke claude-print --dry-run');
   console.log('  npx @colmbyrne/specflow ci-status 76');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "CLAUDE-MD-TEMPLATE.md",
     "CONTRACT-SCHEMA.md",
     "CONTRACT-SCHEMA-EXTENSIONS.md",
+    "MODEL_ROUTING.md",
     "CHANGELOG.md",
     "SKILL.md",
     "LLM-MASTER-PROMPT.md"

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -43,6 +43,11 @@ const REQUIRED_POLICY_FIELDS = [
 ];
 
 const UNKNOWN = 'unknown';
+const DEFAULT_ROUTING_PATHS = [
+  '.specflow/adapter-routing.yml',
+  '.specflow/adapter-routing.yaml',
+  '.specflow/adapter-routing.json',
+];
 
 function ensureDir(path) {
   mkdirSync(dirname(path), { recursive: true });
@@ -116,6 +121,15 @@ function loadDataFile(path) {
   const text = readFileSync(path, 'utf8');
   if (/\.json$/i.test(path)) return JSON.parse(text);
   return yaml.load(text);
+}
+
+function findDefaultAdapterRoutingPath(options = {}) {
+  if (options.adapterRouting) return options.adapterRouting;
+  if (options.noAdapterRouting) return null;
+  for (const candidate of DEFAULT_ROUTING_PATHS) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 function writeYaml(path, value) {
@@ -1137,6 +1151,153 @@ function normalizeAdapterPolicy(raw, context = {}) {
   };
 }
 
+function normalizeRouteKey(loop, stage) {
+  return `${loop}.${stage}`;
+}
+
+function routeValueForStage(routing, contract) {
+  const routes = routing.routes || {};
+  const stage = contract.current_stage_or_rail;
+  const dotted = normalizeRouteKey(contract.loop, stage);
+  if (Object.prototype.hasOwnProperty.call(routes, dotted)) return routes[dotted];
+  if (routes[contract.loop] && Object.prototype.hasOwnProperty.call(routes[contract.loop], stage)) {
+    return routes[contract.loop][stage];
+  }
+  return null;
+}
+
+function loadPolicyRef(ref, routingPath, context = {}) {
+  if (!ref) return null;
+  if (ref.adapter_policy || ref.provider) return normalizeAdapterPolicy(ref, context);
+  if (ref.path) return normalizeAdapterPolicy(loadDataFile(resolve(dirname(routingPath), ref.path)), context);
+  throw new Error('adapter routing policy reference must be an adapter_policy object or path');
+}
+
+function resolvePolicyFromRouting(routing, route, routingPath, context = {}) {
+  const routeObj = typeof route === 'string' ? { policy: route } : route;
+  if (!routeObj || routeObj.policy === false || routeObj.policy === 'none') {
+    return { route: routeObj, policy: null, policyId: null };
+  }
+  const policyRef = routeObj.policy || routeObj.adapter_policy || routeObj;
+  if (typeof policyRef === 'string') {
+    const policies = routing.policies || {};
+    const named = policies[policyRef];
+    if (!named) throw new Error(`adapter routing references unknown policy: ${policyRef}`);
+    return {
+      route: routeObj,
+      policy: loadPolicyRef(named, routingPath, context),
+      policyId: policyRef,
+    };
+  }
+  return {
+    route: routeObj,
+    policy: loadPolicyRef(policyRef, routingPath, context),
+    policyId: routeObj.id || routeObj.policy_id || null,
+  };
+}
+
+function resolveAdapterRouting(options = {}, contract = null) {
+  const routingPath = findDefaultAdapterRoutingPath(options);
+  if (!routingPath || !contract) return { status: 'not_configured', routingPath: null };
+  const routing = loadDataFile(routingPath);
+  if (!routing || typeof routing !== 'object') throw new Error('adapter routing file must be an object');
+  const route = routeValueForStage(routing, contract);
+  if (!route) {
+    return {
+      status: 'no_route',
+      routingPath,
+      loop: contract.loop,
+      stage: contract.current_stage_or_rail,
+    };
+  }
+  const { policy, policyId, route: routeObj } = resolvePolicyFromRouting(routing, route, routingPath, {
+    slug: options.slug || 'run',
+  });
+  const defaults = routing.defaults || {};
+  const confirmationRequired = routeObj?.confirm_models !== undefined
+    ? Boolean(routeObj.confirm_models)
+    : (policy?.confirm_models !== undefined
+      ? Boolean(policy.confirm_models)
+      : defaults.confirm_models !== false);
+  return {
+    status: policy ? 'resolved' : 'none',
+    routingPath,
+    loop: contract.loop,
+    stage: contract.current_stage_or_rail,
+    policyId: policyId || policy?.id || null,
+    policy,
+    route: routeObj,
+    confirmationRequired,
+    reason: routeObj?.reason || policy?.reason || defaults.reason || null,
+  };
+}
+
+function modelConfirmationPlan(resolved, options = {}) {
+  const policy = resolved.policy || {};
+  return {
+    status: 'model_confirmation_required',
+    routing_path: resolved.routingPath,
+    loop: resolved.loop,
+    stage: resolved.stage,
+    policy_id: resolved.policyId || policy.id,
+    provider: policy.provider,
+    role: policy.role || null,
+    effort: policy.effort || null,
+    requested_model: policy.requested_model || policy.model || null,
+    fallback_model: policy.fallback_model || null,
+    max_budget_usd: policy.max_budget_usd ?? null,
+    reason: resolved.reason,
+    transcript_path: policy.transcript_path,
+    output_path: policy.output_path,
+    confirm_with: `specflow run ${resolved.loop} --slug ${options.slug || '<slug>'} --adapter-routing ${resolved.routingPath} --confirm-models`,
+  };
+}
+
+function modelRoutingBriefing(options = {}, contract = null) {
+  const resolved = resolveAdapterRouting(options, contract);
+  if (resolved.status === 'resolved') {
+    const policy = resolved.policy || {};
+    return {
+      active: true,
+      status: 'active',
+      routing_path: resolved.routingPath,
+      loop: resolved.loop,
+      stage: resolved.stage,
+      policy_id: resolved.policyId || policy.id,
+      provider: policy.provider,
+      role: policy.role || null,
+      effort: policy.effort || null,
+      requested_model: policy.requested_model || policy.model || null,
+      fallback_model: policy.fallback_model || null,
+      max_budget_usd: policy.max_budget_usd ?? null,
+      confirmation_required: resolved.confirmationRequired,
+      message: `Model routing active: ${policy.requested_model || policy.model || UNKNOWN} for ${resolved.loop}.${resolved.stage} (${policy.role || 'worker'}).`,
+    };
+  }
+  if (resolved.status === 'no_route' || resolved.status === 'none') {
+    return {
+      active: true,
+      status: resolved.status,
+      routing_path: resolved.routingPath,
+      loop: resolved.loop,
+      stage: resolved.stage,
+      message: `Model routing file found, but no executable model route is configured for ${resolved.loop}.${resolved.stage}.`,
+      next_step: `Add a route for ${resolved.loop}.${resolved.stage} or run with --adapter-policy <path>.`,
+    };
+  }
+  return {
+    active: false,
+    status: 'not_configured',
+    routing_path: null,
+    message: 'Model routing inactive: no .specflow/adapter-routing.yml was found.',
+    setup: [
+      'cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml',
+      'specflow run <loop> --slug <slug> --goal "<goal>" --input <path>',
+      'specflow run <loop> --slug <slug> --confirm-models',
+    ],
+  };
+}
+
 function buildAdapterCommand(policy, promptPath) {
   const allowedTools = policy.allowed_tools || [];
   const deniedTools = policy.denied_tools || [];
@@ -1456,8 +1617,38 @@ function runLoop(options) {
     return { status: 'invalid_contract', errors: validation.errors, contractPath, ledgerPath };
   }
 
-  if (options.adapterPolicy) {
-    const policy = normalizeAdapterPolicy(loadDataFile(options.adapterPolicy), { slug });
+  const routed = !options.adapterPolicy ? resolveAdapterRouting({ ...options, slug }, contract) : null;
+  if (routed && routed.status === 'resolved' && routed.confirmationRequired && !options.confirmModels) {
+    const plan = modelConfirmationPlan(routed, { slug });
+    appendLedger(ledgerPath, {
+      stage: contract.current_stage_or_rail,
+      event: 'model_confirmation',
+      result: 'blocked',
+      stop_reason: 'model_confirmation_required',
+      provider: plan.provider,
+      role: plan.role,
+      effort: plan.effort,
+      requested_model: plan.requested_model,
+      fallback_model: plan.fallback_model,
+      max_budget_usd: plan.max_budget_usd,
+      routing_path: plan.routing_path,
+      policy_id: plan.policy_id,
+    });
+    contract.terminal_status = 'blocked';
+    recordRunState(contract, {
+      contractPath,
+      ledgerPath,
+      status: 'model_confirmation_required',
+      stopReason: 'model_confirmation_required',
+    });
+    writeYaml(contractPath, { run_contract: contract });
+    return { ...plan, contractPath, ledgerPath };
+  }
+
+  if (options.adapterPolicy || (routed && routed.status === 'resolved')) {
+    const policy = options.adapterPolicy
+      ? normalizeAdapterPolicy(loadDataFile(options.adapterPolicy), { slug })
+      : routed.policy;
 
     // VERIFIER-CONTRACT-01 enforcement (#100): a maker may not implement without
     // an accepted verification contract. Enforced once the lifecycle has begun
@@ -1494,7 +1685,13 @@ function runLoop(options) {
       stage: contract.current_stage_or_rail,
       owningGateCommand: options.owningGateCommand,
     });
-    appendLedger(ledgerPath, { ...adapterResult.entry, prompt_path: prompt.promptPath });
+    appendLedger(ledgerPath, {
+      ...adapterResult.entry,
+      prompt_path: prompt.promptPath,
+      routing_path: routed?.routingPath || null,
+      policy_id: routed?.policyId || policy.id,
+      model_confirmation: routed ? 'confirmed' : null,
+    });
     contract.terminal_status = adapterResult.status === 'gate_rerun_required' ? 'in_progress' : 'blocked';
     contract.current_stage_or_rail = adapterResult.status === 'gate_rerun_required' ? contract.current_stage_or_rail : contract.current_stage_or_rail;
     if (adapterResult.entry && adapterResult.entry.session_id) contract.provider_session_id = adapterResult.entry.session_id;
@@ -1553,7 +1750,12 @@ function runLoop(options) {
     });
   }
   writeYaml(contractPath, { run_contract: contract });
-  return { status: registryResult.status, contractPath, ledgerPath };
+  return {
+    status: registryResult.status,
+    contractPath,
+    ledgerPath,
+    model_routing: modelRoutingBriefing({ ...options, slug }, contract),
+  };
 }
 
 function readLedgerTail(ledgerPath, limit = 10) {
@@ -1632,6 +1834,7 @@ function runStatus(options = {}) {
     verifier_trace: verifierTrace({ contract: contractPath, ledger: ledgerPath }),
     reentry: reentryBriefing({ contract: contractPath, ledger: ledgerPath }),
     cost: costAccounting(readLedger(ledgerPath)),
+    model_routing: modelRoutingBriefing(options, contract),
   };
 }
 
@@ -1643,6 +1846,7 @@ function isTerminalStatus(status) {
     'adapter_unavailable',
     'adapter_failed',
     'blocked_human_required',
+    'model_confirmation_required',
     'blocked_verification_required',
     'blocked_verifier_stage',
     'dry_run',
@@ -1743,6 +1947,9 @@ module.exports = {
   releaseWorktree,
   scaffoldRoutineManifest,
   normalizeAdapterPolicy,
+  resolveAdapterRouting,
+  modelConfirmationPlan,
+  modelRoutingBriefing,
   buildAdapterCommand,
   commandExists,
   containsForbiddenAction,

--- a/skills/specflow-loop-selector/SKILL.md
+++ b/skills/specflow-loop-selector/SKILL.md
@@ -46,6 +46,10 @@ run_contract:
 ```
 
 Rules:
+- Before starting `spec-build` or `feature-build`, emit a model-routing confirmation. If `.specflow/adapter-routing.yml` exists, state `Model routing active:` and list the route for the current stage, including provider, role, requested model, fallback model, and budget when present. If no routing file exists, stop before build work and tell the user to run:
+  `cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml`.
+- Routed providers require explicit confirmation before spend. Use `specflow run <loop> --slug <slug> --confirm-models` only after the user has accepted the displayed model choices.
+- If the user explicitly bypasses routing with `--adapter-policy`, still state that this is a one-off override and name the policy/model before invoking it.
 - Load only the selected YAML and its prompt/example if needed.
 - Continue through every currently unblocked stage/rail in the same invocation.
 - Persist evidence to the paths in the run contract; chat-only evidence does not count.

--- a/templates/QA/loops/README.md
+++ b/templates/QA/loops/README.md
@@ -109,6 +109,34 @@ budget where supported, transcript path, output path, allowed/denied tools, and
 actions outside the provider prompt, and requires the owning Specflow gate to
 rerun before state advances.
 
+### Default model routing for larger initiatives
+
+For larger initiatives, install a project routing default:
+
+```bash
+mkdir -p .specflow
+cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml
+```
+
+That default routes expensive requirements/planning/review work to the configured
+Claude/Fable policy and bounded coding/test work to Codex CLI with GPT-5.5. It
+requires confirmation before invoking a routed model:
+
+```bash
+specflow run spec-build --slug auth-system --goal "build auth" --input docs/auth-idea.md --adapter-routing .specflow/adapter-routing.yml
+```
+
+The first run prints the selected provider, role, model, fallback, and budget.
+If the choice is right, rerun with:
+
+```bash
+specflow run spec-build --slug auth-system --adapter-routing .specflow/adapter-routing.yml --confirm-models
+```
+
+The confirmation is intentional: Fable/frontier routes are expensive and should
+not be spent just because an automation resumed. Models do work; Specflow gates,
+CI, and humans still approve.
+
 ## Which repo do I run in?
 
 - **spec-build** produces documents → run where PRDs/journeys live (gmh-docs, or the product repo that owns the spec).

--- a/templates/adapter-policies/claude-code-large-routing.yml
+++ b/templates/adapter-policies/claude-code-large-routing.yml
@@ -1,0 +1,146 @@
+defaults:
+  confirm_models: true
+  reason: Confirm model choices before spending expensive planner/reviewer budget.
+
+policies:
+  fable-planner:
+    adapter_policy:
+      id: fable-planner
+      provider: claude-print
+      command: claude
+      role: planner
+      effort: xhigh
+      args:
+        - -p
+        - --output-format
+        - stream-json
+        - --permission-mode
+        - default
+      model: fable-5
+      requested_model: fable-5
+      fallback_model: opus-4.8
+      max_budget_usd: 20
+      timeout_seconds: 1800
+      max_iterations: 1
+      allowed_tools:
+        - Read
+        - Grep
+        - Glob
+      denied_tools:
+        - Bash(git push *)
+        - Bash(gh pr create *)
+        - Bash(gh pr merge *)
+        - Bash(* deploy *)
+        - Bash(* --no-verify *)
+      transcript_path: .specflow/runs/<slug>/adapter/fable-planner.jsonl
+      output_path: .specflow/runs/<slug>/adapter/fable-planner.md
+      never_without_human:
+        - git push
+        - open PR
+        - merge
+        - production deploy
+        - --no-verify
+        - override contract
+
+  fable-reviewer:
+    adapter_policy:
+      id: fable-reviewer
+      provider: claude-print
+      command: claude
+      role: verifier
+      effort: xhigh
+      args:
+        - -p
+        - --output-format
+        - stream-json
+        - --permission-mode
+        - default
+      model: fable-5
+      requested_model: fable-5
+      fallback_model: opus-4.8
+      max_budget_usd: 12
+      timeout_seconds: 1800
+      max_iterations: 1
+      allowed_tools:
+        - Read
+        - Grep
+        - Glob
+      denied_tools:
+        - Bash(git push *)
+        - Bash(gh pr create *)
+        - Bash(gh pr merge *)
+        - Bash(* deploy *)
+        - Bash(* --no-verify *)
+      transcript_path: .specflow/runs/<slug>/adapter/fable-reviewer.jsonl
+      output_path: .specflow/runs/<slug>/adapter/fable-reviewer.md
+      never_without_human:
+        - git push
+        - open PR
+        - merge
+        - production deploy
+        - --no-verify
+        - override contract
+
+  gpt55-coder:
+    adapter_policy:
+      id: gpt55-coder
+      provider: codex-exec
+      command: codex
+      role: implementer
+      effort: medium
+      args:
+        - --sandbox
+        - workspace-write
+        - --ask-for-approval
+        - never
+      model: gpt-5.5
+      requested_model: gpt-5.5
+      max_budget_usd: 8
+      timeout_seconds: 1800
+      max_iterations: 1
+      allowed_tools: []
+      denied_tools:
+        - git push
+        - gh pr merge
+        - --no-verify
+      transcript_path: .specflow/runs/<slug>/adapter/gpt55-coder.jsonl
+      output_path: .specflow/runs/<slug>/adapter/gpt55-coder.md
+      never_without_human:
+        - git push
+        - open PR
+        - merge
+        - production deploy
+        - --no-verify
+        - override contract
+
+routes:
+  spec-build:
+    discover:
+      policy: fable-planner
+      reason: expensive product/requirements thinking
+    draft:
+      policy: fable-planner
+      reason: expensive PRD shaping
+    adversary:
+      policy: fable-reviewer
+      reason: expensive adversarial review and falsification
+    tickets:
+      policy: gpt55-coder
+      reason: ticket writing is bounded implementation prep
+
+  feature-build:
+    2_contract:
+      policy: gpt55-coder
+      reason: contract expansion from accepted ticket
+    3_e2e:
+      policy: gpt55-coder
+      reason: test authoring
+    4_oracle:
+      policy: gpt55-coder
+      reason: oracle/provenance wiring
+    5_impl:
+      policy: gpt55-coder
+      reason: implementation and local verification
+    review:
+      policy: fable-reviewer
+      reason: independent expensive PR review

--- a/tests/contracts/loop-run-contract.test.js
+++ b/tests/contracts/loop-run-contract.test.js
@@ -13,6 +13,9 @@ const {
   loopSequence,
   materializeStagePrompt,
   normalizeAdapterPolicy,
+  resolveAdapterRouting,
+  modelConfirmationPlan,
+  modelRoutingBriefing,
   parseProviderEvents,
   planAdapterSmoke,
   appendStateMemory,
@@ -254,6 +257,8 @@ describe('local contracted loop runner', () => {
     expect(status.current_stage_or_rail).toBe('6_provenance');
     expect(status.ledger_tail).toHaveLength(1);
     expect(status.ledger_summary.gate_passes).toBe(1);
+    expect(status.model_routing.status).toBe('not_configured');
+    expect(status.model_routing.setup[0]).toContain('claude-code-large-routing.yml');
   });
 
   test('prepares isolated delegated worktree metadata without auto merge or push', () => {
@@ -412,6 +417,111 @@ describe('generative adapter policy and command builders', () => {
     const smoke = planAdapterSmoke('claude-print', { live: false });
     expect(smoke.policy.prompt).toContain('SPECFLOW_ADAPTER_SMOKE_OK');
     expect(smoke.planned.args.join(' ')).toContain('SPECFLOW_ADAPTER_SMOKE_OK');
+  });
+
+  test('resolves default adapter routing for the current loop stage', () => {
+    const dir = tempDir();
+    const routing = path.join(dir, 'adapter-routing.yml');
+    fs.writeFileSync(routing, yaml.dump({
+      defaults: { confirm_models: true },
+      policies: {
+        planner: {
+          adapter_policy: {
+            id: 'planner',
+            provider: 'claude-print',
+            command: 'claude',
+            role: 'planner',
+            effort: 'xhigh',
+            requested_model: 'fable-5',
+            fallback_model: 'opus-4.8',
+            timeout_seconds: 30,
+            max_iterations: 1,
+            transcript_path: path.join(dir, '<slug>-planner.jsonl'),
+            output_path: path.join(dir, '<slug>-planner.md'),
+            never_without_human: ['git push'],
+          },
+        },
+      },
+      routes: {
+        'spec-build.discover': { policy: 'planner', reason: 'requirements thinking' },
+      },
+    }));
+
+    const resolved = resolveAdapterRouting({ adapterRouting: routing, slug: 'auth' }, {
+      loop: 'spec-build',
+      current_stage_or_rail: 'discover',
+    });
+
+    expect(resolved.status).toBe('resolved');
+    expect(resolved.policyId).toBe('planner');
+    expect(resolved.policy.requested_model).toBe('fable-5');
+    expect(resolved.policy.transcript_path).toContain('auth-planner.jsonl');
+    expect(resolved.confirmationRequired).toBe(true);
+
+    const plan = modelConfirmationPlan(resolved, { slug: 'auth' });
+    expect(plan.status).toBe('model_confirmation_required');
+    expect(plan.confirm_with).toContain('--confirm-models');
+
+    const briefing = modelRoutingBriefing({ adapterRouting: routing, slug: 'auth' }, {
+      loop: 'spec-build',
+      current_stage_or_rail: 'discover',
+    });
+    expect(briefing.message).toContain('Model routing active');
+    expect(briefing.requested_model).toBe('fable-5');
+  });
+
+  test('runLoop blocks routed adapter execution until model choices are confirmed', () => {
+    const dir = tempDir();
+    const contract = path.join(dir, 'run-contract.yaml');
+    const ledger = path.join(dir, 'ledger.jsonl');
+    const routing = path.join(dir, 'adapter-routing.yml');
+    fs.writeFileSync(routing, yaml.dump({
+      defaults: { confirm_models: true },
+      policies: {
+        coder: {
+          adapter_policy: {
+            id: 'coder',
+            provider: 'fake',
+            command: 'fake-provider',
+            role: 'implementer',
+            effort: 'medium',
+            requested_model: 'gpt-5.5',
+            timeout_seconds: 30,
+            max_iterations: 1,
+            transcript_path: path.join(dir, '<slug>-transcript.jsonl'),
+            output_path: path.join(dir, '<slug>-final.md'),
+            never_without_human: ['git push'],
+            fake_stdout: JSON.stringify({ type: 'message', text: 'done', model: 'gpt-5.5' }),
+          },
+        },
+      },
+      routes: { 'feature-build.2_contract': { policy: 'coder' } },
+    }));
+    fs.writeFileSync(contract, yaml.dump({
+      run_contract: {
+        loop: 'feature-build',
+        goal: 'auth',
+        input_artifact: 'issue 1',
+        path: 'templates/QA/loops/feature-build.yaml',
+        current_stage_or_rail: '2_contract',
+        next_gate: 'contract',
+        durable_evidence: [contract, ledger],
+        stop_condition: 'handoff',
+        never_without_human: ['git push'],
+        storage: { contract_path: contract, ledger_path: ledger },
+      },
+    }));
+
+    const result = runLoop({ loop: 'feature-build', slug: 'auth', contract, ledger, adapterRouting: routing });
+    expect(result.status).toBe('model_confirmation_required');
+    expect(result.requested_model).toBe('gpt-5.5');
+    expect(fs.existsSync(path.join(dir, 'auth-final.md'))).toBe(false);
+    expect(readJsonl(ledger)[0].stop_reason).toBe('model_confirmation_required');
+
+    const confirmed = runLoop({ loop: 'feature-build', slug: 'auth', contract, ledger, adapterRouting: routing, confirmModels: true });
+    expect(confirmed.status).toBe('gate_rerun_required');
+    expect(fs.readFileSync(path.join(dir, 'auth-final.md'), 'utf8')).toBe('done');
+    expect(readJsonl(ledger).some((entry) => entry.model_confirmation === 'confirmed')).toBe(true);
   });
 
   test('detects forbidden human-gate actions in provider output', () => {


### PR DESCRIPTION
## Summary

- Add `MODEL_ROUTING.md` with operator workflow, technical routing format, safety rules, and default customization examples.
- Link the new guide from the README and include it in package files.
- Add the default Claude/Fable + Codex routing template and runtime confirmation briefing for routed adapter execution.
- Update Specflow skills so agents must announce model routing or setup instructions before spec-build/feature-build work.

## Validation

- `npm test`