### PR TITLE
[codex] Prompt to enable model routing

### DIFF
--- a/MODEL_ROUTING.md
+++ b/MODEL_ROUTING.md
@@ -12,10 +12,19 @@ Models do work. Models do not approve their own work.
 
 ## Quick Start
 
-After `specflow init`, install the large-initiative routing default:
+During `specflow init` or `specflow update`, Specflow asks:
+
+```text
+Enable model routing now? This activates Claude/Fable for planning/review and Codex for coding. [y/N]
+```
+
+Answer `y` to install the large-initiative routing default at
+`.specflow/adapter-routing.yml`.
+
+If you skipped the prompt, enable it later with:
 
 ```bash
-cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml
+specflow run --setup-routing
 ```
 
 Start a loop normally:
@@ -33,9 +42,10 @@ specflow run spec-build --slug auth-system --confirm-models
 ```
 
 If routing is not installed, Specflow reports that model routing is inactive and
-prints the setup command above. Agents using the Specflow skill must announce
-either `Model routing active:` or the setup instruction before starting
-`spec-build` or `feature-build`.
+prints the setup command above. In an interactive terminal, `specflow run` also
+asks whether to enable the default routing before it continues. Agents using the
+Specflow skill must announce either `Model routing active:` or the setup
+instruction before starting `spec-build` or `feature-build`.
 
 ## What The Default Does
 
@@ -173,6 +183,8 @@ Edit:
 ```text
 .specflow/adapter-routing.yml
 ```
+
+If the file does not exist yet, run `specflow run --setup-routing` first.
 
 To use Opus as the primary reviewer instead of Fable, change the reviewer policy:
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ route to Codex CLI with GPT-5.5. Each policy also declares a thinking level
 (`effort`) such as `medium`, `high`, or `xhigh`. The shipped
 `.specflow/adapter-policies/claude-code-large-routing.yml` template requires
 `--confirm-models` before invoking a routed provider, so expensive model choices
-are shown to the operator before spend.
+are shown to the operator before spend. `specflow init`, `specflow update`, and
+interactive `specflow run` can ask whether to enable the default routing; the
+non-interactive shortcut is `specflow run --setup-routing`.
 
 Before any build loop starts, the agent should say either `Model routing active:`
 with the current stage's provider/model choices, or explain how to install the

--- a/SKILL.md
+++ b/SKILL.md
@@ -33,7 +33,7 @@ When this skill is active, Claude Code MUST:
 5. **Never modify `non_negotiable` rules** unless the user explicitly says `override_contract: <contract_id>`.
 6. **Before accepting a ticket as specflow-compliant**: Pre-flight must have run and returned `passed`, `passed_with_warnings`, or a human-acknowledged `override:*` status. A ticket with `blocked`, `stale`, or missing pre-flight section is NOT compliant.
 7. **Before starting spec-build or feature-build work**: Confirm model routing in plain language. If `.specflow/adapter-routing.yml` exists, say `Model routing active:` and list the selected model/policy for the current stage before invoking it. If it does not exist, stop and give the setup command:
-   `cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml`.
+   `specflow run --setup-routing`.
    Expensive/default routed adapters must not run until the user has confirmed the displayed model choices.
 
 ---

--- a/bin/specflow.js
+++ b/bin/specflow.js
@@ -135,7 +135,7 @@ const COMMANDS = {
     },
   },
   run: {
-    usage: 'specflow run <loop> [--slug <slug>] [--goal <goal>] [--input <path>] [--adapter-routing <path>]',
+    usage: 'specflow run <loop> [--slug <slug>] [--goal <goal>] [--input <path>] [--adapter-routing <path>] | specflow run --setup-routing',
     desc: 'Run or resume a local contracted Specflow loop',
     run: (args) => {
       const code = runSpecflowLoop(args);
@@ -268,6 +268,7 @@ if (!command || command === 'help' || command === '--help' || command === '-h') 
   console.log('  npx @colmbyrne/specflow verify');
   console.log('  npx @colmbyrne/specflow audit 500');
   console.log('  npx @colmbyrne/specflow run spec-build --slug my-feature --goal "ready tickets" --input docs/idea.md');
+  console.log('  npx @colmbyrne/specflow run --setup-routing');
   console.log('  npx @colmbyrne/specflow run spec-build --slug my-feature --adapter-routing .specflow/adapter-routing.yml --confirm-models');
   console.log('  npx @colmbyrne/specflow provenance evidence/provenance-77-78-80.json --git-diff');
   console.log('  npx @colmbyrne/specflow adapter-smoke claude-print --dry-run');

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -33,6 +33,48 @@ echo ""
 echo -e "${GREEN}Target:${NC} $TARGET_DIR"
 echo ""
 
+prompt_model_routing() {
+  local template="$TARGET_DIR/.specflow/adapter-policies/claude-code-large-routing.yml"
+  local destination="$TARGET_DIR/.specflow/adapter-routing.yml"
+
+  if [ -f "$destination" ]; then
+    echo -e "${GREEN}✓${NC} Model routing already active → .specflow/adapter-routing.yml"
+    return 0
+  fi
+  if [ ! -f "$template" ]; then
+    echo -e "${YELLOW}⚠️${NC}  Model routing template not found; run specflow update after upgrading Specflow"
+    return 0
+  fi
+
+  case "${SPECFLOW_MODEL_ROUTING:-}" in
+    1|true|TRUE|yes|YES|y|Y)
+      cp "$template" "$destination"
+      echo -e "${GREEN}✓${NC} Enabled model routing → .specflow/adapter-routing.yml"
+      return 0
+      ;;
+    0|false|FALSE|no|NO|n|N)
+      echo -e "${YELLOW}⚠️${NC}  Model routing not enabled"
+      return 0
+      ;;
+  esac
+
+  if [ -t 0 ]; then
+    printf "Enable model routing now? This activates Claude/Fable for planning/review and Codex for coding. [y/N] "
+    read -r answer
+    case "$answer" in
+      y|Y|yes|YES)
+        cp "$template" "$destination"
+        echo -e "${GREEN}✓${NC} Enabled model routing → .specflow/adapter-routing.yml"
+        ;;
+      *)
+        echo -e "${YELLOW}⚠️${NC}  Model routing not enabled. Enable later with: specflow run --setup-routing"
+        ;;
+    esac
+  else
+    echo -e "${YELLOW}⚠️${NC}  Model routing not enabled in non-interactive install. Enable later with: specflow run --setup-routing"
+  fi
+}
+
 # Determine source directory (where this script lives)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOKS_DIR="$SCRIPT_DIR/hooks"
@@ -259,6 +301,7 @@ if [ -d "$ADAPTER_POLICY_DIR" ]; then
     cp "$policy" "$TARGET_DIR/.specflow/adapter-policies/"
     echo -e "${GREEN}✓${NC} Installed .specflow/adapter-policies/$(basename "$policy")"
   done
+  prompt_model_routing
 else
   echo -e "${YELLOW}⚠️${NC}  Adapter policy templates not found in Specflow source"
 fi
@@ -349,6 +392,7 @@ if [ ! -f "$TARGET_DIR/AGENTS.md" ] || ! grep -q "Specflow Loop Routing" "$TARGE
   INSTALL_OK=false
 fi
 for policy_path in \
+  ".specflow/adapter-policies/claude-code-large-routing.yml" \
   ".specflow/adapter-policies/claude-print.safe.yml" \
   ".specflow/adapter-policies/codex-exec.safe.yml"; do
   if [ ! -f "$TARGET_DIR/$policy_path" ]; then

--- a/scripts/specflow-runner.cjs
+++ b/scripts/specflow-runner.cjs
@@ -8,7 +8,7 @@
  */
 
 const { spawnSync } = require('child_process');
-const { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, appendFileSync, statSync } = require('fs');
+const { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, appendFileSync, statSync } = require('fs');
 const { basename, dirname, join, resolve } = require('path');
 const yaml = require('js-yaml');
 
@@ -48,6 +48,7 @@ const DEFAULT_ROUTING_PATHS = [
   '.specflow/adapter-routing.yaml',
   '.specflow/adapter-routing.json',
 ];
+const DEFAULT_ROUTING_TEMPLATE = 'claude-code-large-routing.yml';
 
 function ensureDir(path) {
   mkdirSync(dirname(path), { recursive: true });
@@ -130,6 +131,47 @@ function findDefaultAdapterRoutingPath(options = {}) {
     if (existsSync(candidate)) return candidate;
   }
   return null;
+}
+
+function defaultRoutingTemplatePath(options = {}) {
+  const local = join('.specflow', 'adapter-policies', DEFAULT_ROUTING_TEMPLATE);
+  if (options.routingTemplate) return options.routingTemplate;
+  if (existsSync(local)) return local;
+  return resolve(__dirname, '..', 'templates', 'adapter-policies', DEFAULT_ROUTING_TEMPLATE);
+}
+
+function installDefaultAdapterRouting(options = {}) {
+  const destination = options.adapterRouting || '.specflow/adapter-routing.yml';
+  if (existsSync(destination) && !options.force) {
+    return { status: 'exists', routing_path: destination };
+  }
+  const template = defaultRoutingTemplatePath(options);
+  if (!existsSync(template)) {
+    return {
+      status: 'missing_template',
+      routing_path: destination,
+      template_path: template,
+      error: `model routing template not found: ${template}`,
+    };
+  }
+  ensureDir(destination);
+  copyFileSync(template, destination);
+  return {
+    status: 'installed',
+    routing_path: destination,
+    template_path: template,
+  };
+}
+
+function askYesNo(question, defaultYes = false) {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return null;
+  const suffix = defaultYes ? ' [Y/n] ' : ' [y/N] ';
+  process.stdout.write(`${question}${suffix}`);
+  const buffer = Buffer.alloc(1024);
+  const bytes = require('fs').readSync(0, buffer, 0, buffer.length, null);
+  const answer = buffer.toString('utf8', 0, bytes).trim().toLowerCase();
+  if (!answer) return defaultYes;
+  return answer === 'y' || answer === 'yes';
 }
 
 function writeYaml(path, value) {
@@ -1291,7 +1333,8 @@ function modelRoutingBriefing(options = {}, contract = null) {
     routing_path: null,
     message: 'Model routing inactive: no .specflow/adapter-routing.yml was found.',
     setup: [
-      'cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml',
+      'specflow run --setup-routing',
+      'or: cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml',
       'specflow run <loop> --slug <slug> --goal "<goal>" --input <path>',
       'specflow run <loop> --slug <slug> --confirm-models',
     ],
@@ -1900,8 +1943,17 @@ function planAdapterSmoke(provider, options = {}) {
 function cli(argv = process.argv.slice(2)) {
   const opts = parseKeyValueArgs(argv);
   const loop = opts._[0];
+  if (!loop && opts.setupRouting) {
+    try {
+      console.log(JSON.stringify(installDefaultAdapterRouting(opts), null, 2));
+      return 0;
+    } catch (e) {
+      console.error(`specflow run failed: ${e.message}`);
+      return 1;
+    }
+  }
   if (!loop) {
-    console.error('Usage: specflow run <loop|status|trace> --slug <slug> --goal <goal> --input <path> [--contract path] [--run-dir path] [--until-terminal] [--max-iterations n]');
+    console.error('Usage: specflow run <loop|status|trace> --slug <slug> --goal <goal> --input <path> [--contract path] [--run-dir path] [--until-terminal] [--max-iterations n] [--setup-routing]');
     return 2;
   }
   try {
@@ -1910,7 +1962,23 @@ function cli(argv = process.argv.slice(2)) {
       result = runStatus(opts);
     } else if (loop === 'trace') {
       result = verifierTrace({ runDir: opts.runDir, contract: opts.contract, ledger: opts.ledger });
+    } else if (opts.setupRouting) {
+      result = installDefaultAdapterRouting(opts);
     } else {
+      if (!opts.adapterPolicy && !opts.noAdapterRouting && !findDefaultAdapterRoutingPath(opts)) {
+        const enabled = askYesNo('Model routing is not active. Enable the default Claude/Fable + Codex routing now?', false);
+        if (enabled === true) {
+          const installed = installDefaultAdapterRouting(opts);
+          if (installed.status === 'missing_template') {
+            console.error(installed.error);
+            return 1;
+          }
+          console.error(`Model routing enabled: ${installed.routing_path}`);
+        } else if (enabled === false) {
+          console.error('Model routing not enabled. Continuing without routed adapters.');
+          console.error('To enable later: specflow run --setup-routing');
+        }
+      }
       result = opts.untilTerminal ? runUntilTerminal({ ...opts, loop }) : runLoop({ ...opts, loop });
     }
     if (result.status === 'invalid_contract') {
@@ -1950,6 +2018,7 @@ module.exports = {
   resolveAdapterRouting,
   modelConfirmationPlan,
   modelRoutingBriefing,
+  installDefaultAdapterRouting,
   buildAdapterCommand,
   commandExists,
   containsForbiddenAction,

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -50,6 +50,48 @@ echo -e "${GREEN}Source:${NC} $SCRIPT_DIR"
 echo -e "${GREEN}Target:${NC} $TARGET_DIR"
 echo ""
 
+prompt_model_routing() {
+  local template="$TARGET_DIR/.specflow/adapter-policies/claude-code-large-routing.yml"
+  local destination="$TARGET_DIR/.specflow/adapter-routing.yml"
+
+  if [ -f "$destination" ]; then
+    echo -e "${GREEN}✓${NC} Model routing already active → .specflow/adapter-routing.yml"
+    return 0
+  fi
+  if [ ! -f "$template" ]; then
+    echo -e "${YELLOW}⚠️${NC}  Model routing template not found; run specflow update after upgrading Specflow"
+    return 0
+  fi
+
+  case "${SPECFLOW_MODEL_ROUTING:-}" in
+    1|true|TRUE|yes|YES|y|Y)
+      cp "$template" "$destination"
+      echo -e "${GREEN}✓${NC} Enabled model routing → .specflow/adapter-routing.yml"
+      return 0
+      ;;
+    0|false|FALSE|no|NO|n|N)
+      echo -e "${YELLOW}⚠️${NC}  Model routing not enabled"
+      return 0
+      ;;
+  esac
+
+  if [ -t 0 ]; then
+    printf "Enable model routing now? This activates Claude/Fable for planning/review and Codex for coding. [y/N] "
+    read -r answer
+    case "$answer" in
+      y|Y|yes|YES)
+        cp "$template" "$destination"
+        echo -e "${GREEN}✓${NC} Enabled model routing → .specflow/adapter-routing.yml"
+        ;;
+      *)
+        echo -e "${YELLOW}⚠️${NC}  Model routing not enabled. Enable later with: specflow run --setup-routing"
+        ;;
+    esac
+  else
+    echo -e "${YELLOW}⚠️${NC}  Model routing not enabled in non-interactive install. Enable later with: specflow run --setup-routing"
+  fi
+}
+
 # ============================================================================
 # 1. Directory structure
 # ============================================================================
@@ -149,6 +191,7 @@ if [ -d "$SCRIPT_DIR/templates/adapter-policies" ]; then
   mkdir -p "$TARGET_DIR/.specflow/adapter-policies"
   cp "$SCRIPT_DIR/templates/adapter-policies/"*.yml "$TARGET_DIR/.specflow/adapter-policies/" 2>/dev/null || true
   echo -e "${GREEN}✓${NC} Installed adapter policy templates → .specflow/adapter-policies/"
+  prompt_model_routing
 fi
 
 # Hook sources (for reference — .claude/hooks/ is installed separately)

--- a/skills/specflow-loop-selector/SKILL.md
+++ b/skills/specflow-loop-selector/SKILL.md
@@ -46,8 +46,8 @@ run_contract:
 ```
 
 Rules:
-- Before starting `spec-build` or `feature-build`, emit a model-routing confirmation. If `.specflow/adapter-routing.yml` exists, state `Model routing active:` and list the route for the current stage, including provider, role, requested model, fallback model, and budget when present. If no routing file exists, stop before build work and tell the user to run:
-  `cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml`.
+- Before starting `spec-build` or `feature-build`, emit a model-routing confirmation. If `.specflow/adapter-routing.yml` exists, state `Model routing active:` and list the route for the current stage, including provider, role, requested model, effort, fallback model, and budget when present. If no routing file exists, stop before build work and tell the user to run:
+  `specflow run --setup-routing`.
 - Routed providers require explicit confirmation before spend. Use `specflow run <loop> --slug <slug> --confirm-models` only after the user has accepted the displayed model choices.
 - If the user explicitly bypasses routing with `--adapter-policy`, still state that this is a one-off override and name the policy/model before invoking it.
 - Load only the selected YAML and its prompt/example if needed.

--- a/templates/QA/loops/README.md
+++ b/templates/QA/loops/README.md
@@ -111,11 +111,12 @@ rerun before state advances.
 
 ### Default model routing for larger initiatives
 
-For larger initiatives, install a project routing default:
+For larger initiatives, enable the project routing default during `specflow init`
+or `specflow update` by answering `y` to the model-routing prompt. If you skipped
+the prompt, enable it later with:
 
 ```bash
-mkdir -p .specflow
-cp .specflow/adapter-policies/claude-code-large-routing.yml .specflow/adapter-routing.yml
+specflow run --setup-routing
 ```
 
 That default routes expensive requirements/planning/review work to the configured
@@ -126,7 +127,7 @@ requires confirmation before invoking a routed model:
 specflow run spec-build --slug auth-system --goal "build auth" --input docs/auth-idea.md --adapter-routing .specflow/adapter-routing.yml
 ```
 
-The first run prints the selected provider, role, model, fallback, and budget.
+The first run prints the selected provider, role, model, effort, fallback, and budget.
 If the choice is right, rerun with:
 
 ```bash

--- a/tests/contracts/loop-run-contract.test.js
+++ b/tests/contracts/loop-run-contract.test.js
@@ -16,6 +16,7 @@ const {
   resolveAdapterRouting,
   modelConfirmationPlan,
   modelRoutingBriefing,
+  installDefaultAdapterRouting,
   parseProviderEvents,
   planAdapterSmoke,
   appendStateMemory,
@@ -258,7 +259,7 @@ describe('local contracted loop runner', () => {
     expect(status.ledger_tail).toHaveLength(1);
     expect(status.ledger_summary.gate_passes).toBe(1);
     expect(status.model_routing.status).toBe('not_configured');
-    expect(status.model_routing.setup[0]).toContain('claude-code-large-routing.yml');
+    expect(status.model_routing.setup[0]).toBe('specflow run --setup-routing');
   });
 
   test('prepares isolated delegated worktree metadata without auto merge or push', () => {
@@ -468,6 +469,20 @@ describe('generative adapter policy and command builders', () => {
     });
     expect(briefing.message).toContain('Model routing active');
     expect(briefing.requested_model).toBe('fable-5');
+  });
+
+  test('installs default adapter routing from the local policy template', () => {
+    const dir = tempDir();
+    const template = path.join(dir, '.specflow', 'adapter-policies', 'claude-code-large-routing.yml');
+    const routing = path.join(dir, '.specflow', 'adapter-routing.yml');
+    fs.mkdirSync(path.dirname(template), { recursive: true });
+    fs.writeFileSync(template, 'routes:\n  spec-build.discover:\n    policy: none\n');
+
+    const result = installDefaultAdapterRouting({ adapterRouting: routing, routingTemplate: template });
+
+    expect(result.status).toBe('installed');
+    expect(fs.existsSync(routing)).toBe(true);
+    expect(fs.readFileSync(routing, 'utf8')).toContain('spec-build.discover');
   });
 
   test('runLoop blocks routed adapter execution until model choices are confirmed', () => {

--- a/tests/hooks/installer-fixes.test.js
+++ b/tests/hooks/installer-fixes.test.js
@@ -51,10 +51,11 @@ describe('install-hooks.sh', () => {
     fs.rmSync(targetDir, { recursive: true, force: true });
   });
 
-  function runInstaller(target) {
+  function runInstaller(target, env = {}) {
     return spawnSync('bash', [INSTALLER_PATH, target || targetDir], {
       encoding: 'utf-8',
       timeout: 15000,
+      env: { ...process.env, ...env },
     });
   }
 
@@ -66,6 +67,21 @@ describe('install-hooks.sh', () => {
       expect(fs.existsSync(path.join(targetDir, '.claude', 'settings.json'))).toBe(true);
       expect(fs.existsSync(path.join(targetDir, '.claude', 'hooks', 'post-build-check.sh'))).toBe(true);
       expect(fs.existsSync(path.join(targetDir, '.claude', 'hooks', 'run-journey-tests.sh'))).toBe(true);
+    });
+
+    test('can enable model routing during update/install', () => {
+      const result = runInstaller(targetDir, { SPECFLOW_MODEL_ROUTING: 'yes' });
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(path.join(targetDir, '.specflow', 'adapter-policies', 'claude-code-large-routing.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(targetDir, '.specflow', 'adapter-routing.yml'))).toBe(true);
+      expect(fs.readFileSync(path.join(targetDir, '.specflow', 'adapter-routing.yml'), 'utf8')).toContain('fable-planner');
+    });
+
+    test('leaves model routing inactive when declined', () => {
+      const result = runInstaller(targetDir, { SPECFLOW_MODEL_ROUTING: 'no' });
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(path.join(targetDir, '.specflow', 'adapter-policies', 'claude-code-large-routing.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(targetDir, '.specflow', 'adapter-routing.yml'))).toBe(false);
     });
 
     test('hook scripts are executable', () => {


### PR DESCRIPTION
## Summary

- Add a yes/no activation prompt to `specflow init` and `specflow update` after adapter policy templates are installed.
- Add `specflow run --setup-routing` for non-interactive or skipped activation.
- Let interactive `specflow run` ask whether to enable default routing when no routing file exists.
- Update docs and skills to use the simpler activation path.
- Add tests for installer activation and routing setup.

## Validation

- `npm test`